### PR TITLE
Switch to am matrix structs

### DIFF
--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/CMakeLists.txt
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/CMakeLists.txt
@@ -11,6 +11,13 @@ OPTION (ENABLE_SHADERS ON)
 OPTION (ENABLE_ASSIMP OFF)
 OPTION (ENABLE_AMMARSERVER OFF)
 
+OPTION(INTEL_OPTIMIZATIONS OFF)
+
+if (INTEL_OPTIMIZATIONS)
+add_definitions(-DINTEL_OPTIMIZATIONS)
+endif(INTEL_OPTIMIZATIONS)
+
+
 IF( ENABLE_HIGH_PERFORMANCE_BUILD )
  set(CMAKE_CXX_FLAGS "-fPIC -march=native -mtune=native -O3 -fexpensive-optimizations -s") 
  set(CMAKE_C_FLAGS "-fPIC -march=native -mtune=native -O3 -fexpensive-optimizations -s") 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Applications/BVHTester/main.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Applications/BVHTester/main.c
@@ -48,33 +48,35 @@
 #define CYAN    "\033[36m"      /* Cyan */
 #define WHITE   "\033[37m"      /* White */
 
-void prepare4x4Human36MRotationMatrix(float * rotationMatrix,float rX,float rY,float rZ)
+void prepare4x4Human36MRotationMatrix(struct Matrix4x4OfFloats * rotationMatrix,float rX,float rY,float rZ)
 {
-    float rXM[16],rYM[16],rZM[16];
+    struct Matrix4x4OfFloats rXM={0};
+    struct Matrix4x4OfFloats rYM={0};
+    struct Matrix4x4OfFloats rZM={0};
 
     //R1x=np.matrix([[1,0,0],    [0,np.cos(Rx),-np.sin(Rx)], [0,np.sin(Rx),np.cos(Rx)] ]) #[1 0 0; 0 cos(obj.Params(1)) -sin(obj.Params(1)); 0 sin(obj.Params(1)) cos(obj.Params(1))]
-    rXM[0]=1.0;  rXM[1]=0.0;     rXM[2]=0.0;        rXM[3]=0.0;
-    rXM[4]=0.0;  rXM[5]=cos(rX); rXM[6]=-sin(rX);   rXM[7]=0.0;
-    rXM[8]=0.0;  rXM[9]=sin(rX); rXM[10]=cos(rX);   rXM[11]=0.0;
-    rXM[12]=0.0; rXM[13]=0.0;    rXM[14]=0.0;       rXM[15]=1.0;
+    rXM.m[0]=1.0;  rXM.m[1]=0.0;     rXM.m[2]=0.0;        rXM.m[3]=0.0;
+    rXM.m[4]=0.0;  rXM.m[5]=cos(rX); rXM.m[6]=-sin(rX);   rXM.m[7]=0.0;
+    rXM.m[8]=0.0;  rXM.m[9]=sin(rX); rXM.m[10]=cos(rX);   rXM.m[11]=0.0;
+    rXM.m[12]=0.0; rXM.m[13]=0.0;    rXM.m[14]=0.0;       rXM.m[15]=1.0;
 
     //R1y=np.matrix([[np.cos(Ry),0,np.sin(Ry)], [0,1,0], [-np.sin(Ry),0,np.cos(Ry)]])     #[cos(obj.Params(2)) 0 sin(obj.Params(2)); 0 1 0; -sin(obj.Params(2)) 0 cos(obj.Params(2))]
-    rYM[0]=cos(rY);  rYM[1]=0.0;  rYM[2]=sin(rY);   rYM[3]=0.0;
-    rYM[4]=0.0;      rYM[5]=1.0;  rYM[6]=0.0;       rYM[7]=0.0;
-    rYM[8]=-sin(rY); rYM[9]=0.0;  rYM[10]=cos(rY);  rYM[11]=0.0;
-    rYM[12]=0.0;     rYM[13]=0.0; rYM[14]=0.0;      rYM[15]=1.0;
+    rYM.m[0]=cos(rY);  rYM.m[1]=0.0;  rYM.m[2]=sin(rY);   rYM.m[3]=0.0;
+    rYM.m[4]=0.0;      rYM.m[5]=1.0;  rYM.m[6]=0.0;       rYM.m[7]=0.0;
+    rYM.m[8]=-sin(rY); rYM.m[9]=0.0;  rYM.m[10]=cos(rY);  rYM.m[11]=0.0;
+    rYM.m[12]=0.0;     rYM.m[13]=0.0; rYM.m[14]=0.0;      rYM.m[15]=1.0;
 
     //R1z=np.matrix([[np.cos(Rz),-np.sin(Rz),0], [np.sin(Rz),np.cos(Rz),0], [0,0,1]])     #[cos(obj.Params(3)) -sin(obj.Params(3)) 0; sin(obj.Params(3)) cos(obj.Params(3)) 0; 0 0 1]
-    rZM[0]=cos(rZ); rZM[1]=-sin(rZ); rZM[2]=0.0;    rZM[3]=0.0;
-    rZM[4]=sin(rZ); rZM[5]=cos(rZ);  rZM[6]=0.0;    rZM[7]=0.0;
-    rZM[8]=0.0;     rZM[9]=0.0;      rZM[10]=1.0;   rZM[11]=0.0;
-    rYM[12]=0.0;    rZM[13]=0.0;     rZM[14]=0.0;   rZM[15]=1.0;
+    rZM.m[0]=cos(rZ); rZM.m[1]=-sin(rZ); rZM.m[2]=0.0;    rZM.m[3]=0.0;
+    rZM.m[4]=sin(rZ); rZM.m[5]=cos(rZ);  rZM.m[6]=0.0;    rZM.m[7]=0.0;
+    rZM.m[8]=0.0;     rZM.m[9]=0.0;      rZM.m[10]=1.0;   rZM.m[11]=0.0;
+    rYM.m[12]=0.0;    rZM.m[13]=0.0;     rZM.m[14]=0.0;   rZM.m[15]=1.0;
 
     multiplyThree4x4FMatrices(
                               rotationMatrix ,
-                              rXM ,
-                              rYM,
-                              rZM
+                              &rXM ,
+                              &rYM,
+                              &rZM
                             );
 
 }
@@ -331,7 +333,7 @@ int main(int argc,const char **argv)
           unsigned int width=atoi(argv[i+16]);
           unsigned int height=atoi(argv[i+17]);
           //-------------------------------------------------------------------------------
-          prepare4x4Human36MRotationMatrix(renderingConfiguration.viewMatrix,rX,rY,rZ);
+          prepare4x4Human36MRotationMatrix(&renderingConfiguration.viewMatrix,rX,rY,rZ);
           //copy3x3FMatrixTo4x4F(renderingConfiguration.viewMatrix,renderingConfiguration.R);
 
           // 0  1  2  3
@@ -339,9 +341,9 @@ int main(int argc,const char **argv)
           // 8  9  10 11
           // 12 13 14 15
           //----------------------------------------------------------------
-          renderingConfiguration.viewMatrix[3] =renderingConfiguration.T[0];
-          renderingConfiguration.viewMatrix[7] =renderingConfiguration.T[1];
-          renderingConfiguration.viewMatrix[11]=renderingConfiguration.T[2];
+          renderingConfiguration.viewMatrix.m[3] =renderingConfiguration.T[0];
+          renderingConfiguration.viewMatrix.m[7] =renderingConfiguration.T[1];
+          renderingConfiguration.viewMatrix.m[11]=renderingConfiguration.T[2];
           //----------------------------------------
           renderingConfiguration.viewport[0]=0;
           renderingConfiguration.viewport[1]=0;
@@ -351,7 +353,7 @@ int main(int argc,const char **argv)
           renderingConfiguration.height=height;
           //----------------------------------------
           buildOpenGLProjectionForIntrinsics(
-                                             renderingConfiguration.projection ,
+                                             renderingConfiguration.projection.m ,
                                              renderingConfiguration.viewport ,
                                              renderingConfiguration.fX,
                                              renderingConfiguration.fY,

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Applications/Renderer/main.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Applications/Renderer/main.c
@@ -83,10 +83,10 @@ int reallyFastCheckForLinuxGPUWithoutPBuffer()
 int main(int argc,const char **argv)
 {
 
-    double * rodriguez = (double*) malloc(sizeof(double) * 3 );
-    double * translation = (double*) malloc(sizeof(double) * 3 );
-    double * camera = (double*) malloc(sizeof(double) * 9 );
-    double scaleToDepthUnit = 1.0;
+    float * rodriguez = (float*) malloc(sizeof(float) * 3 );
+    float * translation = (float*) malloc(sizeof(float) * 3 );
+    float * camera = (float*) malloc(sizeof(float) * 9 );
+    float scaleToDepthUnit = 1.0;
 
 
 
@@ -140,7 +140,7 @@ int main(int argc,const char **argv)
                 {
                     camera[z]=atof(argv[z+i+1]);
                 }
-                setOpenGLIntrinsicCalibration( (double*) camera);
+                setOpenGLIntrinsicCalibration( (float*) camera);
             }
         }
         else if (strcmp(argv[i],"--extrinsics")==0)
@@ -154,7 +154,7 @@ int main(int argc,const char **argv)
                 rodriguez[1]=atof(argv[i+5]);
                 rodriguez[2]=atof(argv[i+6]);
                 scaleToDepthUnit = atof(argv[i+7]);
-                setOpenGLExtrinsicCalibration( (double*) rodriguez, (double*) translation , scaleToDepthUnit);
+                setOpenGLExtrinsicCalibration( (float*) rodriguez, (float*) translation , scaleToDepthUnit);
             }
         }
         else if ( (strcmp(argv[i],"--resolution")==0) ||

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Interfaces/webInterface.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Interfaces/webInterface.c
@@ -22,10 +22,10 @@ void * prepareCameraControlCallback(struct AmmServer_DynamicRequest  * rqst)
 {
   char buf[32];
 
-  double translation[4]={0};
+  float translation[4]={0};
   translation[3]=1.0;
 
-  double rotation[4]={0};
+  float rotation[4]={0};
 
   AmmServer_Warning("New Camera State");
   //==============================================================

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader.c
@@ -525,9 +525,9 @@ int drawModelAt(
 
 
    //fprintf(stderr,"drawModelAt: %s -> %u \n", mod->pathOfModel , rotationOrder);
-   double modelTransformation[16];
-   create4x4DModelTransformation(
-                                  modelTransformation,
+   struct Matrix4x4OfFloats modelTransformation={0};
+   create4x4FModelTransformation(
+                                  &modelTransformation,
                                   //Rotation Component
                                   (double) rotationX,//heading,
                                   (double) rotationY,//pitch,
@@ -542,8 +542,8 @@ int drawModelAt(
                                   (double) mod->scaleY,
                                   (double) mod->scaleZ
                                  );
-  transpose4x4DMatrix(modelTransformation); //Because we want to use this in OpenGL
-  glMultMatrixd(modelTransformation);
+  transpose4x4FMatrix(modelTransformation.m); //Because we want to use this in OpenGL
+  glMultMatrixf(modelTransformation.m);
 
 
 /*
@@ -556,7 +556,7 @@ int drawModelAt(
   glGetIntegerv( GL_VIEWPORT, viewport );
   print4x4FMatrix("Projection",projection,0);
   print4x4FMatrix("ModelView",modelview,0);
-  print4x4DMatrix("ModelTransform",modelTransformation,0);
+  print4x4FMatrix("ModelTransform",modelTransformation.m,0);
  // exit (0);
 
   if (checkOpenGLError(__FILE__, __LINE__)) { fprintf(stderr,"drawModelAt error after specifying dimensions \n"); }

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader.c
@@ -529,18 +529,18 @@ int drawModelAt(
    create4x4FModelTransformation(
                                   &modelTransformation,
                                   //Rotation Component
-                                  (double) rotationX,//heading,
-                                  (double) rotationY,//pitch,
-                                  (double) rotationZ,//roll,
+                                  (float) rotationX,//heading,
+                                  (float) rotationY,//pitch,
+                                  (float) rotationZ,//roll,
                                            rotationOrder,
                                   //Translation Component
-                                  (double) positionX,
-                                  (double) positionY,
-                                  (double) positionZ ,
+                                  (float) positionX,
+                                  (float) positionY,
+                                  (float) positionZ ,
                                   //Scale Component
-                                  (double) mod->scaleX,
-                                  (double) mod->scaleY,
-                                  (double) mod->scaleZ
+                                  (float) mod->scaleX,
+                                  (float) mod->scaleY,
+                                  (float) mod->scaleZ
                                  );
   transpose4x4FMatrix(modelTransformation.m); //Because we want to use this in OpenGL
   glMultMatrixf(modelTransformation.m);

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_hardcoded.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_hardcoded.c
@@ -173,7 +173,7 @@ void drawSphere(unsigned int quality)
     #warning "drawSphere should create a call list , otherwise it is a very slow call.."
   #endif
 
-//    double r=1.0;
+  //double r=1.0;
     int lats=quality;
     int longs=quality;
   //---------------

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_hardcoded.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_hardcoded.c
@@ -173,27 +173,27 @@ void drawSphere(unsigned int quality)
     #warning "drawSphere should create a call list , otherwise it is a very slow call.."
   #endif
 
-  //double r=1.0;
+  //float r=1.0;
     int lats=quality;
     int longs=quality;
   //---------------
     int i, j;
     for(i = 0; i <= lats; i++)
     {
-       double lat0 = M_PI * (-0.5 + (double) (i - 1) / lats);
-       double z0  = sin(lat0);
-       double zr0 =  cos(lat0);
+       float lat0 = M_PI * (-0.5 + (float) (i - 1) / lats);
+       float z0  = sin(lat0);
+       float zr0 =  cos(lat0);
 
-       double lat1 = M_PI * (-0.5 + (double) i / lats);
-       double z1 = sin(lat1);
-       double zr1 = cos(lat1);
+       float lat1 = M_PI * (-0.5 + (float) i / lats);
+       float z1 = sin(lat1);
+       float zr1 = cos(lat1);
 
        glBegin(GL_QUAD_STRIP);
        for(j = 0; j <= longs; j++)
         {
-           double lng = 2 * M_PI * (double) (j - 1) / longs;
-           double x = cos(lng);
-           double y = sin(lng);
+           float lng = 2 * M_PI * (float) (j - 1) / longs;
+           float x = cos(lng);
+           float y = sin(lng);
 
            glNormal3f(x * zr0, y * zr0, z0);
            glVertex3f(x * zr0, y * zr0, z0);
@@ -210,27 +210,27 @@ void initializeSphere()
 {
   fprintf(stderr,"TODO : initializeSphere not implemented because it has quads instead of triangles..\n");
   return;
-//    double r=1.0;
+//    float r=1.0;
     int lats=SPHERE_QUALITY;
     int longs=SPHERE_QUALITY;
   //---------------
     int i, j;
     for(i = 0; i <= lats; i++)
     {
-       double lat0 = M_PI * (-0.5 + (double) (i - 1) / lats);
-       double z0  = sin(lat0);
-       double zr0 =  cos(lat0);
+       float lat0 = M_PI * (-0.5 + (float) (i - 1) / lats);
+       float z0  = sin(lat0);
+       float zr0 =  cos(lat0);
 
-       double lat1 = M_PI * (-0.5 + (double) i / lats);
-       double z1 = sin(lat1);
-       double zr1 = cos(lat1);
+       float lat1 = M_PI * (-0.5 + (float) i / lats);
+       float z1 = sin(lat1);
+       float zr1 = cos(lat1);
 
        glBegin(GL_QUAD_STRIP);
        for(j = 0; j <= longs; j++)
         {
-           double lng = 2 * M_PI * (double) (j - 1) / longs;
-           double x = cos(lng);
-           double y = sin(lng);
+           float lng = 2 * M_PI * (float) (j - 1) / longs;
+           float x = cos(lng);
+           float y = sin(lng);
 
            glNormal3f(x * zr0, y * zr0, z0);
            glVertex3f(x * zr0, y * zr0, z0);

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_obj.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_obj.c
@@ -1138,7 +1138,7 @@ static inline int findIntersectionInternal(struct OBJ_Model * obj,Face triangle,
 	Vector e1, e2, p, s, q;
 	Vector bcoords;
 	float t,u,v, tmp, e=0.000001;
-	double l, new_normal_length;
+	float l, new_normal_length;
 	Vector v0,v1,v2,dir;
 	Vector origin, end;
 	origin.n1 = p1.x;
@@ -1207,9 +1207,9 @@ static inline int findIntersectionInternal(struct OBJ_Model * obj,Face triangle,
 
     Vector tmpVec = *new_normal;
 	new_normal_length = VectorLength(tmpVec);
-	new_normal->n1 /=new_normal_length;
-	new_normal->n2 /=new_normal_length;
-	new_normal->n3 /=new_normal_length;
+	new_normal->n1 /= new_normal_length;
+	new_normal->n2 /= new_normal_length;
+	new_normal->n3 /= new_normal_length;
 
 	intersection_point->n1 = dir.n1 * t + origin.n1;
 	intersection_point->n2 = dir.n2 * t + origin.n2;

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_transform_joints.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_transform_joints.c
@@ -178,13 +178,10 @@ void HsvToRgb(float h,float S,float V, float * r, float * g, float * b)
 
 
 void getDistinctColor3F_ForID(unsigned int id,unsigned maxID , float *oR,float *oG,float *oB)
-{
-
+{ 
   unsigned int sCoef=10;
   unsigned int vCoef=40;
-
-
-
+ 
   unsigned int hStep = (unsigned int) 360/maxID;
   unsigned int sStep = (unsigned int) sCoef/maxID;
   unsigned int vStep = (unsigned int) vCoef/maxID;
@@ -575,10 +572,10 @@ void colorCodeBones(struct TRI_Model * in)
 
 
 int setTRIJointRotationOrder(
-                                 struct TRI_Model * in ,
-                                 unsigned int jointToChange ,
-                                 unsigned int rotationOrder
-                               )
+                             struct TRI_Model * in ,
+                             unsigned int jointToChange ,
+                             unsigned int rotationOrder
+                           )
 {
   if (in==0)        { return 0; }
   if (in->bones==0) { return 0; }

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_transform_joints.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_transform_joints.c
@@ -878,6 +878,8 @@ int applyVertexTransformation( struct TRI_Model * triModelOut , struct TRI_Model
   memset(triModelOut->vertices, 0, triModelOut->header.numberOfVertices  * sizeof(float));
   memset(triModelOut->normal  , 0, triModelOut->header.numberOfNormals   * sizeof(float));
 
+  struct  Matrix4x4OfFloats alignedMatrixHolder;
+
    for (k=0; k<triModelIn->header.numberOfBones; k++ )
    {
      if ( is4x4FZeroMatrix(triModelIn->bones[k].info->finalVertexTransformation) )
@@ -894,6 +896,8 @@ int applyVertexTransformation( struct TRI_Model * triModelOut , struct TRI_Model
 
      for (i=0; i<triModelIn->bones[k].info->boneWeightsNumber; i++ )
      {
+       copy4x4FMatrix(alignedMatrixHolder.m,triModelIn->bones[k].info->finalVertexTransformation);
+         
        //V is the vertice we will be working in this loop
        unsigned int v = triModelIn->bones[k].weightIndex[i];
        //W is the weight that we have for the specific bone
@@ -908,7 +912,7 @@ int applyVertexTransformation( struct TRI_Model * triModelOut , struct TRI_Model
        position[3] = 1.0;
 
        //We transform input (initial) position with the transform we computed to get transformedPosition
-       transform3DPointFVectorUsing4x4FMatrix(transformedPosition, triModelIn->bones[k].info->finalVertexTransformation ,position);
+       transform3DPointFVectorUsing4x4FMatrix(transformedPosition,&alignedMatrixHolder,position);
        triModelOut->vertices[v*3+0] += (float) transformedPosition[0] * w;
        triModelOut->vertices[v*3+1] += (float) transformedPosition[1] * w;
        triModelOut->vertices[v*3+2] += (float) transformedPosition[2] * w;
@@ -922,7 +926,7 @@ int applyVertexTransformation( struct TRI_Model * triModelOut , struct TRI_Model
        normal[3]   = 0.0;
 
        //We transform input (initial) normal with the transform we computed to get transformedNormal
-       transform3DNormalVectorUsing3x3DPartOf4x4DMatrix(transformedNormal, triModelIn->bones[k].info->finalVertexTransformation ,normal);
+       transform3DNormalVectorUsing3x3FPartOf4x4FMatrix(transformedNormal,&alignedMatrixHolder,normal);
        triModelOut->normal[v*3+0] += (float) transformedNormal[0] * w;
        triModelOut->normal[v*3+1] += (float) transformedNormal[1] * w;
        triModelOut->normal[v*3+2] += (float) transformedNormal[2] * w;

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_tri.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_tri.c
@@ -35,7 +35,7 @@
 
 
 
-void print4x4DMatrixTRI(const char * str , double * matrix4x4)
+void print4x4FMatrixTRI(const char * str , float * matrix4x4)
 {
   fprintf( stderr, "  %s \n",str);
   fprintf( stderr, "--------------------------------------\n");
@@ -82,9 +82,9 @@ void printTRIBoneStructure(struct TRI_Model * triModel, int alsoPrintMatrices)
 
      if (alsoPrintMatrices)
         {
-         print4x4DMatrixTRI("matrixThatTransformsFromMeshSpaceToBoneSpaceInBindPose", triModel->bones[i].info->matrixThatTransformsFromMeshSpaceToBoneSpaceInBindPose );
-         print4x4DMatrixTRI("finalVertexTransformation", triModel->bones[i].info->finalVertexTransformation );
-         print4x4DMatrixTRI("localTransformation", triModel->bones[i].info->localTransformation );
+         print4x4FMatrixTRI("matrixThatTransformsFromMeshSpaceToBoneSpaceInBindPose", triModel->bones[i].info->matrixThatTransformsFromMeshSpaceToBoneSpaceInBindPose );
+         print4x4FMatrixTRI("finalVertexTransformation", triModel->bones[i].info->finalVertexTransformation );
+         print4x4FMatrixTRI("localTransformation", triModel->bones[i].info->localTransformation );
         }
      }
    }

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_tri.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/ModelLoader/model_loader_tri.h
@@ -29,7 +29,7 @@ extern "C"
          to keep the spec as clean as possible
 * @ingroup TRI
 */
-#define TRI_LOADER_VERSION 9
+#define TRI_LOADER_VERSION 10
 ///IF I EVER CHANGE THE VERSION AGAIN I SHOULD ALWAYS UPDATE LAST STABLE COMMIT INSIDE MODEL_LOADER_TRI..!
 
 
@@ -51,22 +51,22 @@ struct TRI_Bones_Header
   unsigned int boneWeightsNumber;
   unsigned int boneNameSize;
 //-------------------------------------------
-  double matrixThatTransformsFromMeshSpaceToBoneSpaceInBindPose[16]; //selfdescriptive
-  double finalVertexTransformation[16]; //What we will use in the end
-  double localTransformation[16]; // or node->mTransformation
+  float matrixThatTransformsFromMeshSpaceToBoneSpaceInBindPose[16]; //selfdescriptive
+  float finalVertexTransformation[16]; //What we will use in the end
+  float localTransformation[16]; // or node->mTransformation
   unsigned char altered;
 
   //Bone center location and dimension
-  double x , dimX;
-  double y , dimY;
-  double z , dimZ;
+  float x , dimX;
+  float y , dimY;
+  float z , dimZ;
   unsigned char bonePositionSet;
 
   //Bone rotation setting
-  double minXRotation , rotX , maxXRotation;
-  double minYRotation , rotY , maxYRotation;
-  double minZRotation , rotZ , maxZRotation;
-  double minWRotation , rotW , maxWRotation;
+  float minXRotation , rotX , maxXRotation;
+  float minYRotation , rotY , maxYRotation;
+  float minZRotation , rotZ , maxZRotation;
+  float minWRotation , rotW , maxWRotation;
 
   unsigned char rotationSet , rotationLimitsSet;
   unsigned char isEulerRotation;
@@ -120,7 +120,7 @@ struct TRI_Header
      unsigned int numberOfIndices;
      unsigned int numberOfBones;
      unsigned int rootBone;
-     double boneGlobalInverseTransform[16];
+     float boneGlobalInverseTransform[16];
 
      //In order not to break this file format ever again
      unsigned int notUsed1;
@@ -188,12 +188,12 @@ struct TRI_Container
 
 
 /**
-* @brief Printout the values of an array of 16 values ( double val[16]; ) that contains a 4x4 Matrix
+* @brief Printout the values of an array of 16 values ( float val[16]; ) that contains a 4x4 Matrix
 * @ingroup TRI
 * @param  string label to include in the printout
-* @param  pointer to the 4x4 double matrix
+* @param  pointer to the 4x4 float matrix
 */
-void print4x4DMatrixTRI(const char * str , double * matrix4x4);
+void print4x4FMatrixTRI(const char * str , float * matrix4x4);
 
 /**
 * @brief Printout the bone structure of a TRI model

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/bvh_loader.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/bvh_loader.c
@@ -262,15 +262,15 @@ int bvh_ConstrainRotations(
   {
    unsigned int mID=fID*mc->numberOfValuesPerFrame;
 
-   double buffer = (double) mc->motionValues[mID+3];
+   float buffer = (float) mc->motionValues[mID+3];
    buffer = bvh_RemapAngleCentered0(buffer,0);
    mc->motionValues[mID+3] = (float) buffer;
 
-   buffer = (double) mc->motionValues[mID+4];
+   buffer = (float) mc->motionValues[mID+4];
    buffer = bvh_RemapAngleCentered0(buffer,constrainOrientation);
    mc->motionValues[mID+4] = (float) buffer;
 
-   buffer = (double) mc->motionValues[mID+5];
+   buffer = (float) mc->motionValues[mID+5];
    buffer = bvh_RemapAngleCentered0(buffer,0);
    mc->motionValues[mID+5] = (float) buffer;
   }

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/bvh_loader.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/bvh_loader.c
@@ -582,7 +582,7 @@ int bvh_changeJointDimensions(
        bvhMotion->jointHierarchy[jID].offset[angleZ] *= zScale;
        //fprintf(stderr,"offset is now %0.2f %0.2f %0.2f\n",bvhMotion->jointHierarchy[jID].offset[0],bvhMotion->jointHierarchy[jID].offset[1],bvhMotion->jointHierarchy[jID].offset[2]);
 
-       float * m = bvhMotion->jointHierarchy[jID].staticTransformation;
+       float * m = bvhMotion->jointHierarchy[jID].staticTransformation.m;
        m[0] =1.0;  m[1] =0.0;  m[2] =0.0;  m[3] = (float) bvhMotion->jointHierarchy[jID].offset[0];
        m[4] =0.0;  m[5] =1.0;  m[6] =0.0;  m[7] = (float) bvhMotion->jointHierarchy[jID].offset[1];
        m[8] =0.0;  m[9] =0.0;  m[10]=1.0;  m[11]= (float) bvhMotion->jointHierarchy[jID].offset[2];
@@ -618,7 +618,7 @@ int bvh_scaleAllOffsets(
       bvhMotion->jointHierarchy[jID].offset[1] = bvhMotion->jointHierarchy[jID].offset[1] * scalingRatio;
       bvhMotion->jointHierarchy[jID].offset[2] = bvhMotion->jointHierarchy[jID].offset[2] * scalingRatio;
 
-       float * m = bvhMotion->jointHierarchy[jID].staticTransformation;
+       float * m = bvhMotion->jointHierarchy[jID].staticTransformation.m;
        m[0] =1.0;  m[1] =0.0;  m[2] =0.0;  m[3] = (float) bvhMotion->jointHierarchy[jID].offset[0];
        m[4] =0.0;  m[5] =1.0;  m[6] =0.0;  m[7] = (float) bvhMotion->jointHierarchy[jID].offset[1];
        m[8] =0.0;  m[9] =0.0;  m[10]=1.0;  m[11]= (float) bvhMotion->jointHierarchy[jID].offset[2];

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/bvh_loader.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/bvh_loader.h
@@ -15,8 +15,9 @@ extern "C"
 #endif
 
 //BVH Code version
-static const char BVH_LOADER_VERSION_STRING [] = "0.41";
+static const char BVH_LOADER_VERSION_STRING [] = "0.43";
 
+#include "../../../../../tools/AmMatrix/matrix4x4Tools.h"
 
 /**
 * @brief MAX_BVH_JOINT_NAME is the maximum label size for Joint names
@@ -158,7 +159,7 @@ struct BVH_Joint
   unsigned int hierarchyLevel;
   //--------------------
   float offset[3];
-  float staticTransformation[16];
+  struct Matrix4x4OfFloats staticTransformation;
   //--------------------
   char  channelType[BVH_VALID_CHANNEL_NAMES];
   char  channelRotationOrder;

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_project.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_project.c
@@ -228,9 +228,9 @@ int bvh_projectTo2D(
                                );
 
             //Should this only happen when position2DW>=0.0
-            //bvhTransform->joint[jID].pos3D[0] = (double) pos3DCenterFloat[0];
-            //bvhTransform->joint[jID].pos3D[1] = (double) pos3DCenterFloat[1];
-            //bvhTransform->joint[jID].pos3D[2] = (double) pos3DCenterFloat[2];               );
+            //bvhTransform->joint[jID].pos3D[0] = (float) pos3DCenterFloat[0];
+            //bvhTransform->joint[jID].pos3D[1] = (float) pos3DCenterFloat[1];
+            //bvhTransform->joint[jID].pos3D[2] = (float) pos3DCenterFloat[2];               );
            }
     //-------------------------------------------------------------------------------------------
 
@@ -241,8 +241,8 @@ int bvh_projectTo2D(
               bvhTransform->joint[jID].isBehindCamera=1;
            } else
            {
-              bvhTransform->joint[jID].pos2D[0] = (double) position2D[0];
-              bvhTransform->joint[jID].pos2D[1] = (double) position2D[1];
+              bvhTransform->joint[jID].pos2D[0] = (float) position2D[0];
+              bvhTransform->joint[jID].pos2D[1] = (float) position2D[1];
               bvhTransform->joint[jID].pos2DCalculated=1;
            }
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_project.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_project.h
@@ -6,6 +6,7 @@
 
 
 #include "../../../../../../tools/AmMatrix/simpleRenderer.h"
+#include "../../../../../../tools/AmMatrix/matrix4x4Tools.h"
 
 
 #ifdef __cplusplus
@@ -27,11 +28,9 @@ struct BVH_RendererConfiguration
   //----------
   //float R[9];
   float T[4];
-  float projection[16];
-  float viewMatrix[16];
-  int viewport[4];
-
-
+  struct Matrix4x4OfFloats projection;
+  struct Matrix4x4OfFloats viewMatrix;
+  int viewport[4]; 
 };
 
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
@@ -14,12 +14,7 @@
 #define FAST_OFFSET_TRANSLATION 1
 
 
-
-double fToD(float in)
-{
-  return (double) in;
-}
-
+ 
 
 float max(float a,float b)
 {

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
@@ -543,7 +543,7 @@ int bvh_loadTransformForMotionBuffer(
                         bvhMotion->jointHierarchy[jID].jointName
                        );
               }
-          create4x4FIdentityMatrix(bvhTransform->joint[jID].dynamicRotation);
+          create4x4FIdentityMatrix(&bvhTransform->joint[jID].dynamicRotation);
        } else
       {
        #if USE_BVH_SPECIFIC_ROTATIONS

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
@@ -526,7 +526,7 @@ int bvh_loadTransformForMotionBuffer(
       if (bhv_populatePosXYZRotXYZFromMotionBuffer(bvhMotion,jID,motionBuffer,data,sizeof(data)))
       {
        create4x4FTranslationMatrix(
-                                    bvhTransform->joint[jID].dynamicTranslation,
+                                    &bvhTransform->joint[jID].dynamicTranslation,
                                     data[MOTIONBUFFER_DATA_FIELDS_POSX],
                                     data[MOTIONBUFFER_DATA_FIELDS_POSY],
                                     data[MOTIONBUFFER_DATA_FIELDS_POSZ]

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
@@ -433,13 +433,13 @@ int bvh_loadTransformForMotionBuffer(
         }
 
 
-        multiplyTwo4x4FMatrices(
+        multiplyTwo4x4FMatricesS(
                                 //Output AxB
-                                bvhTransform->joint[jID].localToWorldTransformation ,
+                                &bvhTransform->joint[jID].localToWorldTransformation ,
                                 //Parent Output A
-                                bvhTransform->joint[parentID].chainTransformation,
+                                &bvhTransform->joint[parentID].chainTransformation,
                                 //This Transform B
-                                bvhMotion->jointHierarchy[jID].staticTransformation
+                                &bvhMotion->jointHierarchy[jID].staticTransformation
                               );
       } else
       if ( bvhMotion->jointHierarchy[jID].isRoot)
@@ -474,13 +474,13 @@ int bvh_loadTransformForMotionBuffer(
       }
 
     bvhTransform->joint[jID].isChainTrasformationComputed=1;
-    multiplyTwo4x4FMatrices(
+    multiplyTwo4x4FMatricesS(
                            //Output AxB
-                           bvhTransform->joint[jID].chainTransformation ,
+                           &bvhTransform->joint[jID].chainTransformation ,
                            //A
-                           bvhTransform->joint[jID].localToWorldTransformation,
+                           &bvhTransform->joint[jID].localToWorldTransformation,
                            //B
-                           bvhTransform->joint[jID].dynamicRotation
+                           &bvhTransform->joint[jID].dynamicRotation
                           );
 
   #if FIND_FAST_CENTER

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
@@ -3,8 +3,7 @@
 #include "bvh_transform.h"
 
 #include "../../../../../../tools/AmMatrix/matrix4x4Tools.h"
-
-#define USE_BVH_SPECIFIC_ROTATIONS 0
+ 
 
 //Also find Center of Joint
 //We can skip the matrix multiplication by just grabbing the last column..
@@ -200,162 +199,7 @@ int bvh_populateRectangle2DFromProjections(
  return 0;
 }
 
-
-
-
-#if USE_BVH_SPECIFIC_ROTATIONS
-
-///This code here is provided for the random guy that will wonder how the BVH transformations happen..
-//instead of shifting through thousands of lines of code I have compacted the calls needed here so that
-//you can easily understand how the transformations happen..
-/*
-   0  1  2  3
-   4  5  6  7
-   8  9 10 11
-  12 13 14 15
-*/
-
-/*
-   [0,0]  [1,0]  [2,0]  [3,0]
-   [0,1]  [1,1]  [2,1]  [3,1]
-   [0,2]  [1,2]  [2,2]  [3,2]
-   [0,3]  [1,3]  [2,3]  [3,3]
-*/
-//---------------------------------------------------------
-double degrees_to_radBVH(double degrees)
-{
-    return (double) degrees * ( (double)  M_PI /180.0);
-}
-//---------------------------------------------------------
-void create4x4RotationBVH_X(double * m,double degrees)
-{
-    double radians = degrees_to_radBVH(degrees);
-
-    create4x4DIdentityMatrix(m);
-
-    double cosV = (double) cosf((float)radians);
-    double sinV = (double) sinf((float)radians);
-
-    // Rotate X formula.
-    m[5] =    cosV; // [1,1]
-    m[9] = -1*sinV; // [1,2]
-    m[6] =    sinV; // [2,1]
-    m[10] =   cosV; // [2,2]
-}
-//---------------------------------------------------------
-void create4x4RotationBVH_Y(double * m,double degrees)
-{
-    double radians = degrees_to_radBVH(degrees);
-
-    create4x4DIdentityMatrix(m);
-
-    double cosV = (double) cosf((float)radians);
-    double sinV = (double) sinf((float)radians);
-
-    // Rotate Y formula.
-    m[0] =    cosV; // [0,0]
-    m[2] = -1*sinV; // [2,0]
-    m[8] =    sinV; // [0,2]
-    m[10] =   cosV; // [2,2]
-}
-//---------------------------------------------------------
-void create4x4RotationBVH_Z(double * m,double degrees)
-{
-    double radians = degrees_to_radBVH(degrees);
-
-    create4x4DIdentityMatrix(m);
-
-    double cosV = (double) cosf((float)radians);
-    double sinV = (double) sinf((float)radians);
-
-    // Rotate Z formula.
-    m[0] =    cosV;  // [0,0]
-    m[1] =    sinV;  // [1,0]
-    m[4] = -1*sinV;  // [0,1]
-    m[5] =    cosV;  // [1,1]
-}
-//---------------------------------------------------------
-
-
-
-//As http://research.cs.wisc.edu/graphics/Courses/cs-838-1999/Jeff/BVH.html?fbclid=IwAR0Hq96gIhAq-6mvi8OAfMJid2qkv7ZIGNxNMna4vBNngILoceulshvxMfc states
-//To calculate the position of a segment you first create a transformation matrix from the local translation and rotation information for that segment. For any joint segment the translation information will simply be the offset as defined in the hierarchy section. The rotation data comes from the motion section. For the root object, the translation data will be the sum of the offset data and the translation data from the motion section. The BVH format doesn't account for scales so it isn't necessary to worry about including a scale factor calculation.
-//A straightforward way to create the rotation matrix is to create 3 separate rotation matrices, one for each axis of rotation. Then concatenate the matrices from left to right Y, X and Z.
-//
-//vR = vYXZ
-void create4x4RotationBVH(double * matrix,int rotationType,double degreesX,double degreesY,double degreesZ)
-{
-  double rX[16]={0};
-  double rY[16]={0};
-  double rZ[16]={0};
-
-  //Initialize rotation matrix..
-  create4x4DIdentityMatrix(matrix);
-
-  if (rotationType==0)
-  {
-    //No rotation type, get's you back an Identity Matrix..
-    return;
-  }
-
-//Assuming the rotation axis are correct
-//rX,rY,rZ should hold our rotation matrices
-   create4x4RotationBVH_X(rX,degreesX);
-   create4x4RotationBVH_Y(rY,degreesY);
-   create4x4RotationBVH_Z(rZ,degreesZ);
-
-
-//TODO : Fix correct order..
-//http://www.dcs.shef.ac.uk/intranet/research/public/resmes/CS0111.pdf
-//https://github.com/duststorm/BVwHacker <- this is a good guide for the transform order..
-
-  switch (rotationType)
-  {
-    case BVH_ROTATION_ORDER_XYZ :
-      //This is what happens with poser exported bvh files..
-      //multiplyThree4x4Matrices( matrix, rX, rY, rZ );
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rX);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rY);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rZ);
-    break;
-    case BVH_ROTATION_ORDER_XZY :
-      //multiplyThree4x4Matrices( matrix, rX, rZ, rY );
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rX);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rZ);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rY);
-    break;
-    case BVH_ROTATION_ORDER_YXZ :
-      //multiplyThree4x4Matrices( matrix, rY, rX, rZ );
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rY);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rX);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rZ);
-    break;
-    case BVH_ROTATION_ORDER_YZX :
-      //multiplyThree4x4Matrices( matrix, rY, rZ, rX );
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rY);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rZ);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rX);
-    break;
-    case BVH_ROTATION_ORDER_ZXY :
-      //This is what happens most of the time with bvh files..
-      //multiplyThree4x4Matrices( matrix, rZ, rX, rY );
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rZ);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rX);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rY);
-    break;
-    case BVH_ROTATION_ORDER_ZYX :
-      //multiplyThree4x4Matrices( matrix, rZ, rY, rX );
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rZ);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rY);
-      multiplyTwo4x4DMatricesBuffered(matrix,matrix,rX);
-    break;
-    default :
-      fprintf(stderr,"Error, Incorrect rotation type %u\n",rotationType);
-    break;
-  };
-
-}
-#endif // USE_BVH_SPECIFIC_ROTATIONS
+ 
 
 
 int bvh_shouldJoinBeTransformedGivenOurOptimizations(struct BVH_Transform * bvhTransform,BVHJointID jID)
@@ -545,30 +389,20 @@ int bvh_loadTransformForMotionBuffer(
               }
           create4x4FIdentityMatrix(&bvhTransform->joint[jID].dynamicRotation);
        } else
-      {
-       #if USE_BVH_SPECIFIC_ROTATIONS
-       create4x4RotationBVH(
-                            bvhTransform->joint[jID].dynamicRotation,
-                            bvhMotion->jointHierarchy[jID].channelRotationOrder,
-                            -1*data[MOTIONBUFFER_DATA_FIELDS_ROTX],
-                            -1*data[MOTIONBUFFER_DATA_FIELDS_ROTY],
-                            -1*data[MOTIONBUFFER_DATA_FIELDS_ROTZ]
-                           );
-       #else
+      { 
        create4x4FMatrixFromEulerAnglesWithRotationOrder(
-                                                       bvhTransform->joint[jID].dynamicRotation,
-                                                       -1*data[MOTIONBUFFER_DATA_FIELDS_ROTX],
-                                                       -1*data[MOTIONBUFFER_DATA_FIELDS_ROTY],
-                                                       -1*data[MOTIONBUFFER_DATA_FIELDS_ROTZ],
-                                                       (unsigned int) bvhMotion->jointHierarchy[jID].channelRotationOrder
-                                                      );
-       #endif // USE_BVH_SPECIFIC_ROTATIONS
+                                                        &bvhTransform->joint[jID].dynamicRotation,
+                                                        -1*data[MOTIONBUFFER_DATA_FIELDS_ROTX],
+                                                        -1*data[MOTIONBUFFER_DATA_FIELDS_ROTY],
+                                                        -1*data[MOTIONBUFFER_DATA_FIELDS_ROTZ],
+                                                        (unsigned int) bvhMotion->jointHierarchy[jID].channelRotationOrder
+                                                       ); 
       }
      } else
      {
       fprintf(stderr,"Error extracting dynamic transformation for jID=%u and a motionBuffer\n",jID);
-      create4x4FIdentityMatrix(bvhTransform->joint[jID].dynamicTranslation);
-      create4x4FIdentityMatrix(bvhTransform->joint[jID].dynamicRotation);
+      create4x4FIdentityMatrix(&bvhTransform->joint[jID].dynamicTranslation);
+      create4x4FIdentityMatrix(&bvhTransform->joint[jID].dynamicRotation);
      }
     }
   }
@@ -595,7 +429,7 @@ int bvh_loadTransformForMotionBuffer(
         {
          //This is needed because we access the chain transform of our parent so at some point this will get used..
          bvhTransform->joint[parentID].isChainTrasformationComputed=1;
-         create4x4FIdentityMatrix(bvhTransform->joint[parentID].chainTransformation);
+         create4x4FIdentityMatrix(&bvhTransform->joint[parentID].chainTransformation);
         }
 
 
@@ -615,12 +449,13 @@ int bvh_loadTransformForMotionBuffer(
         #if FAST_OFFSET_TRANSLATION
          //Skip the matrix multiplication..
          create4x4FTranslationMatrix(
-                                     bvhTransform->joint[jID].localToWorldTransformation,
-                                     bvhMotion->jointHierarchy[jID].staticTransformation[3]  + bvhTransform->joint[jID].dynamicTranslation[3],
-                                     bvhMotion->jointHierarchy[jID].staticTransformation[7]  + bvhTransform->joint[jID].dynamicTranslation[7],
-                                     bvhMotion->jointHierarchy[jID].staticTransformation[11] + bvhTransform->joint[jID].dynamicTranslation[11]
+                                     &bvhTransform->joint[jID].localToWorldTransformation,
+                                     bvhMotion->jointHierarchy[jID].staticTransformation.m[3]  + bvhTransform->joint[jID].dynamicTranslation.m[3],
+                                     bvhMotion->jointHierarchy[jID].staticTransformation.m[7]  + bvhTransform->joint[jID].dynamicTranslation.m[7],
+                                     bvhMotion->jointHierarchy[jID].staticTransformation.m[11] + bvhTransform->joint[jID].dynamicTranslation.m[11]
                                     );
         #else
+        /*
          multiplyTwo4x4FMatrices(
                                 //Output AxB
                                 bvhTransform->joint[jID].localToWorldTransformation ,
@@ -629,11 +464,13 @@ int bvh_loadTransformForMotionBuffer(
                                 //B
                                 bvhTransform->joint[jID].dynamicTranslation
                               );
+                               * 
+        */
         #endif // FAST_OFFSET_TRANSLATION
       } else
       {
         //Weird case where joint is not root and doesnt have parents(?)
-        create4x4FIdentityMatrix(bvhTransform->joint[jID].localToWorldTransformation);
+        create4x4FIdentityMatrix(&bvhTransform->joint[jID].localToWorldTransformation);
       }
 
     bvhTransform->joint[jID].isChainTrasformationComputed=1;
@@ -647,10 +484,10 @@ int bvh_loadTransformForMotionBuffer(
                           );
 
   #if FIND_FAST_CENTER
-   bvhTransform->joint[jID].pos3D[0]= bvhTransform->joint[jID].localToWorldTransformation[3];
-   bvhTransform->joint[jID].pos3D[1]= bvhTransform->joint[jID].localToWorldTransformation[7];
-   bvhTransform->joint[jID].pos3D[2]= bvhTransform->joint[jID].localToWorldTransformation[11];
-   bvhTransform->joint[jID].pos3D[3]= bvhTransform->joint[jID].localToWorldTransformation[15];
+   bvhTransform->joint[jID].pos3D[0]= bvhTransform->joint[jID].localToWorldTransformation.m[3];
+   bvhTransform->joint[jID].pos3D[1]= bvhTransform->joint[jID].localToWorldTransformation.m[7];
+   bvhTransform->joint[jID].pos3D[2]= bvhTransform->joint[jID].localToWorldTransformation.m[11];
+   bvhTransform->joint[jID].pos3D[3]= bvhTransform->joint[jID].localToWorldTransformation.m[15];
    normalize3DPointFVector(bvhTransform->joint[jID].pos3D);
   #else
    double centerPoint[4]={0.0,0.0,0.0,1.0};

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.c
@@ -490,7 +490,7 @@ int bvh_loadTransformForMotionBuffer(
    bvhTransform->joint[jID].pos3D[3]= bvhTransform->joint[jID].localToWorldTransformation.m[15];
    normalize3DPointFVector(bvhTransform->joint[jID].pos3D);
   #else
-   double centerPoint[4]={0.0,0.0,0.0,1.0};
+   float centerPoint[4]={0.0,0.0,0.0,1.0};
    transform3DPointFVectorUsing4x4FMatrix(
                                           bvhTransform->joint[jID].pos3D,
                                           bvhTransform->joint[jID].localToWorldTransformation,

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.h
@@ -10,7 +10,7 @@
 #define BVH_TRANSFORM_H_INCLUDED
 
 #include "../bvh_loader.h"
-
+#include "../../../../../../tools/AmMatrix/matrix4x4Tools.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -67,10 +67,10 @@ struct BVH_TransformedJoint
 
   //Transforms
   //-----------------
-  float localToWorldTransformation[16];
-  float chainTransformation[16];
-  float dynamicTranslation[16];
-  float dynamicRotation[16];
+  struct Matrix4x4OfFloats localToWorldTransformation;
+  struct Matrix4x4OfFloats chainTransformation;
+  struct Matrix4x4OfFloats dynamicTranslation;
+  struct Matrix4x4OfFloats dynamicRotation;
 
   //Position as X,Y,Z
   //-----------------

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/calculate/bvh_transform.h
@@ -10,7 +10,6 @@
 #define BVH_TRANSFORM_H_INCLUDED
 
 #include "../bvh_loader.h"
-#include "../../../../../../tools/AmMatrix/matrix4x4Tools.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_remapangles.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_remapangles.c
@@ -37,10 +37,10 @@ double bvh_constrainAngleCentered180(double angle)
 //
 //
 //We want to add 180 degrees to the model so 0 is oriented towards us..!
-double bvh_constrainAngleCentered0(double angle,unsigned int flipOrientation)
+float bvh_constrainAngleCentered0(float angle,unsigned int flipOrientation)
 {
-    double angleFrom_minus360_to_plus360;
-    double angleRotated = angle+180;
+    float angleFrom_minus360_to_plus360;
+    float angleRotated = angle+180;
 
      if (angleRotated<0.0)
      {
@@ -64,9 +64,9 @@ double bvh_constrainAngleCentered0(double angle,unsigned int flipOrientation)
 
 
 
-double bvh_RemapAngleCentered0(double angle, unsigned int constrainOrientation)
+float bvh_RemapAngleCentered0(float angle, unsigned int constrainOrientation)
 {
-   double angleShifted = angle;
+   float angleShifted = angle;
    //We want to add 180 degrees to the model so 0 is oriented towards us..!
    switch (constrainOrientation)
    {

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_remapangles.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_remapangles.c
@@ -6,7 +6,7 @@
 
 /*
 //THIS IS NOT USED ANYWHERE
-double bvh_constrainAngleCentered180(double angle)
+float bvh_constrainAngleCentered180(float angle)
 {
    angle = fmod(angle,360.0);
    if (angle<0.0)

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_remapangles.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/edit/bvh_remapangles.h
@@ -8,9 +8,9 @@ extern "C"
 {
 #endif
 
-double bvh_RemapAngleCentered0(double angle, unsigned int constrainOrientation);
+float bvh_RemapAngleCentered0(float angle, unsigned int constrainOrientation);
 
-double bvh_constrainAngleCentered0(double angle,unsigned int flipOrientation);
+float bvh_constrainAngleCentered0(float angle,unsigned int flipOrientation);
 
 
 #ifdef __cplusplus

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/export/bvh_to_csv.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/export/bvh_to_csv.c
@@ -507,8 +507,8 @@ int dumpBVHToCSVBody(
                   //Test using :
                   //rm tmp/bvh_test.csv tmp/2d_test.csv && ./BVHTester --from Motions/MotionCapture/01/01_02.bvh  --repeat 0 --selectJoints 17 hip abdomen chest neck head rshoulder relbow rhand lshoulder lelbow lhand rhip rknee rfoot lhip lknee lfoot --csvOrientation right --randomize2D 1000 5000 -35 45 -35 35 135 35 --occlusions --csv tmp test.csv 2d+bvh
                   //value=666; <- highlight the correct
-                  //value=(float) bvh_constrainAngleCentered0((double) value,0);
-                  value=(float) bvh_RemapAngleCentered0((double) value,csvOrientation);
+                  //value=(float) bvh_constrainAngleCentered0((float) value,0);
+                  value=(float) bvh_RemapAngleCentered0((float) value,csvOrientation);
               }
              }
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/export/bvh_to_svg.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/export/bvh_to_svg.c
@@ -26,7 +26,7 @@ int dumpBVHToSVGFrame(
               renderer->cameraOffsetPosition[0]*10,renderer->cameraOffsetPosition[1]*10,renderer->cameraOffsetPosition[2]*10);
 
       unsigned int x=10;
-      float * m = renderer->projectionMatrix;
+      float * m = renderer->projectionMatrix.m;
       fprintf(fp,"<text x=\"%u\" y=\"45\">Projection Matrix</text>\n",x);
       fprintf(fp,"<text x=\"%u\" y=\"60\">%0.2f %0.2f %0.2f %0.2f</text>\n" ,x,m[0],m[1],m[2],m[3]);
       fprintf(fp,"<text x=\"%u\" y=\"75\">%0.2f %0.2f %0.2f %0.2f</text>\n" ,x,m[4],m[5],m[6],m[7]);
@@ -35,7 +35,7 @@ int dumpBVHToSVGFrame(
 
 
       x=150;
-      m = renderer->modelViewMatrix;
+      m = renderer->modelViewMatrix.m;
       fprintf(fp,"<text x=\"%u\" y=\"45\">ModelView Matrix</text>\n",x);
       fprintf(fp,"<text x=\"%u\" y=\"60\">%0.2f %0.2f %0.2f %0.2f</text>\n" ,x,m[0],m[1],m[2],m[3]);
       fprintf(fp,"<text x=\"%u\" y=\"75\">%0.2f %0.2f %0.2f %0.2f</text>\n" ,x,m[4],m[5],m[6],m[7]);
@@ -43,7 +43,7 @@ int dumpBVHToSVGFrame(
       fprintf(fp,"<text x=\"%u\" y=\"105\">%0.2f %0.2f %0.2f %0.2f</text>\n",x,m[12],m[13],m[14],m[15]);
 
       x=300;
-      m = renderer->viewMatrix;
+      m = renderer->viewMatrix.m;
       fprintf(fp,"<text x=\"%u\" y=\"45\">View Matrix</text>\n",x);
       fprintf(fp,"<text x=\"%u\" y=\"60\">%0.2f %0.2f %0.2f %0.2f</text>\n" ,x,m[0],m[1],m[2],m[3]);
       fprintf(fp,"<text x=\"%u\" y=\"75\">%0.2f %0.2f %0.2f %0.2f</text>\n" ,x,m[4],m[5],m[6],m[7]);
@@ -51,7 +51,7 @@ int dumpBVHToSVGFrame(
       fprintf(fp,"<text x=\"%u\" y=\"105\">%0.2f %0.2f %0.2f %0.2f</text>\n",x,m[12],m[13],m[14],m[15]);
 
       x=450;
-      m = renderer->modelMatrix;
+      m = renderer->modelMatrix.m;
       fprintf(fp,"<text x=\"%u\" y=\"45\">Model Matrix</text>\n",x);
       fprintf(fp,"<text x=\"%u\" y=\"60\">%0.2f %0.2f %0.2f %0.2f</text>\n" ,x,m[0],m[1],m[2],m[3]);
       fprintf(fp,"<text x=\"%u\" y=\"75\">%0.2f %0.2f %0.2f %0.2f</text>\n" ,x,m[4],m[5],m[6],m[7]);

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/ik/hardcodedProblems_inverseKinematics.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/ik/hardcodedProblems_inverseKinematics.c
@@ -507,6 +507,7 @@ int prepareDefaultBodyProblem(
     else
     {
         fprintf(stderr,"No R toe in armature..\n");
+        bvh_printBVH(mc);
         return 0;
     }
 
@@ -602,6 +603,7 @@ int prepareDefaultBodyProblem(
     else
     {
         fprintf(stderr,"No L toe in armature..\n");
+        bvh_printBVH(mc);
         return 0;
     }
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/ik/hardcodedProblems_inverseKinematics.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/ik/hardcodedProblems_inverseKinematics.c
@@ -494,7 +494,7 @@ int prepareDefaultBodyProblem(
     }
 
 
-    if ( (bvh_getJointIDFromJointName(mc,"EndSite_toe1-2.r",&thisJID) )  || (bvh_getJointIDFromJointName(mc,"endsite_toe1-2.r",&thisJID)) )
+    if ( (bvh_getJointIDFromJointName(mc,"EndSite_toe1-2.r",&thisJID) )  || (bvh_getJointIDFromJointNameNocase(mc,"endsite_toe1-2.r",&thisJID)) )
     {
         bvh_markJointAndParentsAsUsefulInTransform(mc,&problem->chain[chainID].current2DProjectionTransform,thisJID);
         problem->chain[chainID].part[partID].partParent=2;
@@ -506,8 +506,8 @@ int prepareDefaultBodyProblem(
     }
     else
     {
-        fprintf(stderr,"No R toe in armature..\n");
         bvh_printBVH(mc);
+        fprintf(stderr,"No R toe in armature..\n");
         return 0;
     }
 
@@ -590,7 +590,7 @@ int prepareDefaultBodyProblem(
         return 0;
     }
 
-    if ( (bvh_getJointIDFromJointName(mc,"EndSite_toe1-2.l",&thisJID) )  || (bvh_getJointIDFromJointName(mc,"endsite_toe1-2.l",&thisJID)) )
+    if ( (bvh_getJointIDFromJointName(mc,"EndSite_toe1-2.l",&thisJID) )  || (bvh_getJointIDFromJointNameNocase(mc,"endsite_toe1-2.l",&thisJID)) )
     {
         bvh_markJointAndParentsAsUsefulInTransform(mc,&problem->chain[chainID].current2DProjectionTransform,thisJID);
         problem->chain[chainID].part[partID].partParent=2;
@@ -602,8 +602,8 @@ int prepareDefaultBodyProblem(
     }
     else
     {
-        fprintf(stderr,"No L toe in armature..\n");
         bvh_printBVH(mc);
+        fprintf(stderr,"No L toe in armature..\n");
         return 0;
     }
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/import/fromBVH.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/import/fromBVH.c
@@ -404,11 +404,11 @@ int readBVHHeader(struct BVH_MotionCapture * bvhMotion , FILE * fd )
                 }
                  
                  //Create 4x4 Matrix that contains the static transformation ( translation ) of the joint
-                 float * m = bvhMotion->jointHierarchy[currentJoint].staticTransformation;
+                 float * m = bvhMotion->jointHierarchy[currentJoint].staticTransformation.m;
                  m[0] =1.0;    m[1] =0.0;   m[2] =0.0;    m[3] = (float) bvhMotion->jointHierarchy[currentJoint].offset[0];
                  m[4] =0.0;    m[5] =1.0;   m[6] =0.0;    m[7] = (float) bvhMotion->jointHierarchy[currentJoint].offset[1];
-                 m[8] =0.0;    m[9] =0.0;   m[10]=1.0;  m[11]= (float) bvhMotion->jointHierarchy[currentJoint].offset[2];
-                 m[12]=0.0;  m[13]=0.0;  m[14]=0.0;  m[15]=1.0; 
+                 m[8] =0.0;    m[9] =0.0;   m[10]=1.0;    m[11]= (float) bvhMotion->jointHierarchy[currentJoint].offset[2];
+                 m[12]=0.0;    m[13]=0.0;   m[14]=0.0;    m[15]=1.0; 
                   //---------------------------------------------------------------------------------------------------------------------
                   //---------------------------------------------------------------------------------------------------------------------
                   //---------------------------------------------------------------------------------------------------------------------

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/tests/test.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/MotionCaptureLoader/tests/test.c
@@ -37,7 +37,7 @@ int bvh_testConstrainRotations()
   /*
   fprintf(stderr,"Testing bvh_rotation constraint\n");
   unsigned int i=0;
-  double angle = -720;
+  float angle = -720;
   for (i=0; i<1440; i++)
   {
     fprintf(stderr,"| Angle:%0.2f | Centered at 0:%0.2f | Flipped at 0:%0.2f\n", //| Centered at 180:%0.2f
@@ -54,7 +54,7 @@ int bvh_testConstrainRotations()
 
   fprintf(stderr,"Testing bvh_rotation front constraint\n");
   unsigned int i=0;
-  double angle = -45;
+  float angle = -45;
   for (i=0; i<90; i++)
   {
     fprintf(stderr,"| Angle:%0.2f | Front Centered at 0 :%0.2f\n", //| Centered at 180:%0.2f

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/OGLRendererSandbox.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/OGLRendererSandbox.h
@@ -26,7 +26,7 @@ void internalTest();
 * @param Far plane
 * @retval 0=Failure,1=Success
 */
-int setOpenGLNearFarPlanes(double near , double far);
+int setOpenGLNearFarPlanes(float near ,float far);
 
 
 /**
@@ -36,7 +36,7 @@ int setOpenGLNearFarPlanes(double near , double far);
 * @bug Careful about providing Column/Row Major matrices
 * @retval 0=Failure,1=Success
 */
-int setOpenGLIntrinsicCalibration(double * camera);
+int setOpenGLIntrinsicCalibration(float * camera);
 
 
 /**
@@ -47,7 +47,7 @@ int setOpenGLIntrinsicCalibration(double * camera);
 * @param Scale of translation
 * @retval 0=Failure,1=Success
 */
-int setOpenGLExtrinsicCalibration(double * rodriguez,double * translation , double scaleToDepthUnit);
+int setOpenGLExtrinsicCalibration(float * rodriguez,float * translation , float scaleToDepthUnit);
 
 
 unsigned int getOpenGLTimestamp();
@@ -96,14 +96,14 @@ int enableShaders(const char * vertShaderFilename ,const char * fragShaderFilena
 * @ingroup OGLRendererSandbox
 * @retval Focal Length
 */
-double getOpenGLFocalLength();
+float getOpenGLFocalLength();
 
 /**
 * @brief Get Virtual Pixel Size
 * @ingroup OGLRendererSandbox
 * @retval Pixel Size
 */
-double getOpenGLPixelSize();
+float getOpenGLPixelSize();
 
 
 /**

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/FixedPipeline/ogl_fixed_pipeline_renderer.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/FixedPipeline/ogl_fixed_pipeline_renderer.c
@@ -117,11 +117,10 @@ int stopOGLFixedRendering(struct rendererConfiguration * config)
 
 
 
-void doOGLFixedBoneDrawCalllist( float * pos , unsigned int * parentNode ,  unsigned int boneSizes)
+void doOGLFixedBoneDrawCalllist(float * pos , unsigned int * parentNode ,  unsigned int boneSizes)
 {
   unsigned int bone=0;
-
-
+ 
   glLineWidth(6.0);
   for (bone=0; bone<boneSizes; bone++)
   {
@@ -156,32 +155,32 @@ void doOGLFixedBoneDrawCalllist( float * pos , unsigned int * parentNode ,  unsi
 
 
      int quality=20;
-//    double r=1.0;
-    int lats=quality;
-    int longs=quality;
+  // float r=1.0;
+     int lats=quality;
+     int longs=quality;
   //---------------
     int i, j;
     for(i = 0; i <= lats; i++)
     {
-       double lat0 = M_PI * (-0.5 + (double) (i - 1) / lats);
-       double z0  = sin(lat0);
-       double zr0 =  cos(lat0);
+       float lat0 = M_PI * (-0.5 + (float) (i - 1) / lats);
+       float z0  = sin(lat0);
+       float zr0 =  cos(lat0);
 
-       double lat1 = M_PI * (-0.5 + (double) i / lats);
-       double z1 = sin(lat1);
-       double zr1 = cos(lat1);
+       float lat1 = M_PI * (-0.5 + (float) i / lats);
+       float z1 = sin(lat1);
+       float zr1 = cos(lat1);
 
   //---------------
    glPushMatrix();
     glTranslatef(pos[bone*3+0],pos[bone*3+1],pos[bone*3+2]);
-       glScalef( boneSphere , boneSphere , boneSphere );
+       glScalef(boneSphere,boneSphere,boneSphere);
        glBegin(GL_QUAD_STRIP);
        glColor3f(0.74,0.01,1.0);
        for(j = 0; j <= longs; j++)
         {
-           double lng = 2 * M_PI * (double) (j - 1) / longs;
-           double x = cos(lng);
-           double y = sin(lng);
+           float lng = 2 * M_PI * (float) (j - 1) / longs;
+           float x = cos(lng);
+           float y = sin(lng);
 
            glNormal3f(x * zr0, y * zr0, z0);
            glVertex3f(x * zr0, y * zr0, z0);

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/ShaderPipeline/uploadGeometry.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/ShaderPipeline/uploadGeometry.c
@@ -82,11 +82,11 @@ pushObjectToBufferData(
     //Pass vNormal to shader
     if ((normals!=0) && (sizeOfNormals!=0) )
     {
-     GLuint vNormal = glGetAttribLocation( programID, "vNormal" );                             checkOpenGLError(__FILE__, __LINE__);
+     GLuint vNormal = glGetAttribLocation(programID, "vNormal");                             checkOpenGLError(__FILE__, __LINE__);
      if (GL_INVALID_OPERATION != vNormal)
      {
-      glEnableVertexAttribArray( vNormal );                                                     checkOpenGLError(__FILE__, __LINE__);
-      glVertexAttribPointer( vNormal, 3, GL_FLOAT, GL_FALSE, 0,BUFFER_OFFSET(sizeOfVertices) ); checkOpenGLError(__FILE__, __LINE__);
+      glEnableVertexAttribArray(vNormal );                                                    checkOpenGLError(__FILE__, __LINE__);
+      glVertexAttribPointer(vNormal, 3,GL_FLOAT, GL_FALSE, 0,BUFFER_OFFSET(sizeOfVertices));  checkOpenGLError(__FILE__, __LINE__);
      }
     }
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/downloadFromRenderer.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/downloadFromRenderer.c
@@ -284,7 +284,7 @@ int downloadOpenGLColorFromTexture(const char * filename , unsigned int tex, uns
     char * pixelsC = (char * ) malloc(sizeof(char) * 3 * width * height);
     if (pixelsC!=0)
     {
-     float * pixels3CPTR = pixels3C;
+     float * pixels3CPTR = (float*) pixels3C;
      char  * pixelPTR = pixelsC;
      char  * pixelLimit = pixelsC+(3 * width * height);
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/tiledRenderer.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/tiledRenderer.c
@@ -205,7 +205,7 @@ int tiledRenderer_Render( struct tiledRendererConfiguration * trConf)
                     gldPerspective(
                                    matrixF,
                                    85.0,
-                                   (double) tileWidth/tileHeight,
+                                   (float) tileWidth/tileHeight,
                                    0.1,
                                    13500.0
                                   );

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/tiledRenderer.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Rendering/tiledRenderer.c
@@ -201,15 +201,15 @@ int tiledRenderer_Render( struct tiledRendererConfiguration * trConf)
                    #define USE_OUR_OWN 1
 
                    #if USE_OUR_OWN
-                    double matrixD[16];
+                    float matrixF[16];
                     gldPerspective(
-                                   matrixD,
+                                   matrixF,
                                    85.0,
                                    (double) tileWidth/tileHeight,
                                    0.1,
                                    13500.0
                                   );
-                    glMultMatrixd(matrixD);
+                    glMultMatrixf(matrixF);
                    #else
                     gluPerspective( 85.0, (GLfloat)(tileWidth)/(GLfloat)(tileHeight), 0.1f, 13500.0 );
                    #endif // USE_OUR_OWN

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Scene/scene.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Scene/scene.c
@@ -745,9 +745,10 @@ int setupSceneCameraBeforeRendering(struct VirtualStream * scene)
   if (scene!=0)
   {
     /* fprintf(stderr,"Using on the fly rotate/translate rot x,y,z ( %0.2f,%0.2f,%0.2f ) trans x,y,z, (  %0.2f,%0.2f,%0.2f ) \n", camera_angle_x,camera_angle_y,camera_angle_z, camera_pos_x,camera_pos_y,camera_pos_z ); */
-
-    create4x4DCameraModelViewMatrixForRendering(
-                                                scene->activeModelViewMatrix ,
+    
+    struct Matrix4x4OfFloats aMVM={0};
+    create4x4FCameraModelViewMatrixForRendering(
+                                                &aMVM,
                                                 //Rotation Component
                                                 scene->cameraPose.angleX,
                                                 scene->cameraPose.angleY,
@@ -757,6 +758,8 @@ int setupSceneCameraBeforeRendering(struct VirtualStream * scene)
                                                 scene->cameraPose.posY,
                                                 scene->cameraPose.posZ
                                                );
+                                               
+    copy4x4FMatrixTo4x4D(scene->activeModelViewMatrix,aMVM.m); 
     transpose4x4DMatrix(scene->activeModelViewMatrix);
     glLoadMatrixd(scene->activeModelViewMatrix);
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Scene/scene.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Scene/scene.c
@@ -113,7 +113,7 @@ int sceneSetOpenGLExtrinsicCalibration(struct VirtualStream * scene,float * rodr
   if (scene==0) { fprintf(stderr,"Cannot access virtual stream to sceneSetOpenGLExtrinsicCalibration\n"); return 0; }
 
   scene->useCustomModelViewMatrix=1;
-  convertRodriguezAndTranslationToOpenGL4x4DProjectionMatrix(scene->customModelViewMatrix , rodriguez , translation , scaleToDepthUnit);
+  convertRodriguezAndTranslationToOpenGL4x4ProjectionMatrix(scene->customModelViewMatrix , rodriguez , translation , scaleToDepthUnit);
 
   scene->controls.scaleDepthTo=(float) scaleToDepthUnit;
 
@@ -180,7 +180,7 @@ int updateProjectionMatrix()
     if ( (WIDTH==0) || (HEIGHT==0) ) { fprintf(stderr,"Null dimensions for viewport"); }
     glViewport(0,0,WIDTH,HEIGHT);
 
-    print4x4DMatrix("OpenGL Projection Matrix Given by Trajectory Parser", scene->projectionMatrix ,0 );
+    print4x4FMatrix("OpenGL Projection Matrix Given by Trajectory Parser", scene->projectionMatrix ,0 );
 
   } else
   if (scene->useIntrinsicMatrix)
@@ -202,10 +202,9 @@ int updateProjectionMatrix()
                                              scene->controls.farPlane
                                            );
 
-   print4x4DMatrix("OpenGL Projection Matrix", scene->customProjectionMatrix , 0 );
-
+   print4x4FMatrix("OpenGL Projection Matrix", scene->customProjectionMatrix , 0 ); 
    glMatrixMode(GL_PROJECTION);
-   glLoadMatrixd(scene->customProjectionMatrix); // we load a matrix of Doubles
+   glLoadMatrixf(scene->customProjectionMatrix); // we load a matrix of Doubles
    glViewport(viewport[0],viewport[1],viewport[2],viewport[3]);
   }
     else
@@ -214,16 +213,15 @@ int updateProjectionMatrix()
    glMatrixMode(GL_PROJECTION);
    glLoadIdentity();
 
-   double matrix[16]={0};
-
+   float matrix[16]={0}; 
    gldPerspective(
                   matrix,
-                  (double) scene->controls.fieldOfView,
-                  (double) WIDTH/HEIGHT,
-                  (double) scene->controls.nearPlane,
-                  (double) scene->controls.farPlane
+                  (float) scene->controls.fieldOfView,
+                  (float) WIDTH/HEIGHT,
+                  (float) scene->controls.nearPlane,
+                  (float) scene->controls.farPlane
                  );
-   glMultMatrixd(matrix);
+   glMultMatrixf(matrix);
 
    //glFrustum(-1.0, 1.0, -1.0, 1.0, nearPlane , farPlane);
    glViewport(0, 0, WIDTH, HEIGHT);
@@ -720,7 +718,7 @@ int setupSceneCameraBeforeRendering(struct VirtualStream * scene)
       if (scene->useCustomModelViewMatrix)
          {
            fprintf(stderr,"Please not that the model view matrix has been overwritten by the scene configuration parameter\n");
-           print4x4DMatrix("Scene declared modelview matrix", scene->modelViewMatrix , 0);
+           print4x4FMatrix("Scene declared modelview matrix", scene->modelViewMatrix , 0);
          }
 
    checkOpenGLError(__FILE__, __LINE__);

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Scene/scene.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Scene/scene.c
@@ -108,7 +108,7 @@ int sceneSwitchKeyboardControl(int newVal)
  return 1;
 }
 
-int sceneSetOpenGLExtrinsicCalibration(struct VirtualStream * scene, double * rodriguez,double * translation , double scaleToDepthUnit)
+int sceneSetOpenGLExtrinsicCalibration(struct VirtualStream * scene,float * rodriguez,float * translation ,float scaleToDepthUnit)
 {
   if (scene==0) { fprintf(stderr,"Cannot access virtual stream to sceneSetOpenGLExtrinsicCalibration\n"); return 0; }
 
@@ -130,7 +130,7 @@ int sceneSetOpenGLExtrinsicCalibration(struct VirtualStream * scene, double * ro
   return 1;
 }
 
-int sceneSetOpenGLIntrinsicCalibration(struct VirtualStream * scene,double * camera)
+int sceneSetOpenGLIntrinsicCalibration(struct VirtualStream * scene,float * camera)
 {
   if (scene==0) { fprintf(stderr,"Cannot sceneSetOpenGLIntrinsicCalibration without an initialized VirtualStream\n"); return 0;}
 
@@ -161,12 +161,12 @@ int updateProjectionMatrix()
      }
      fprintf(stderr,"Emulating Projection Matrix from Trajectory Parser");
      int viewport[4]={0};
-     double fx = scene->emulateProjectionMatrix[0];
-     double fy = scene->emulateProjectionMatrix[4];
-     double skew = 0.0;
-     double cx = scene->emulateProjectionMatrix[2];
-     double cy = scene->emulateProjectionMatrix[5];
-     buildOpenGLProjectionForIntrinsics_OpenGLColumnMajorD( scene->projectionMatrix , viewport , fx, fy, skew, cx,  cy, WIDTH, HEIGHT, scene->controls.nearPlane, scene->controls.farPlane);
+     float fx = scene->emulateProjectionMatrix[0];
+     float fy = scene->emulateProjectionMatrix[4];
+     float skew = 0.0;
+     float cx = scene->emulateProjectionMatrix[2];
+     float cy = scene->emulateProjectionMatrix[5];
+     buildOpenGLProjectionForIntrinsics_OpenGLColumnMajor(scene->projectionMatrix,viewport,fx,fy,skew,cx,cy,WIDTH,HEIGHT,scene->controls.nearPlane,scene->controls.farPlane);
      scene->projectionMatrixDeclared =1;
      fprintf(stderr,"Updated projection matrix using 3x3 matrix");
   }
@@ -175,7 +175,7 @@ int updateProjectionMatrix()
   { //Scene configuration overwrites local configuration
     fprintf(stderr,"Custom projection matrix is declared\n");
     glMatrixMode(GL_PROJECTION);
-    glLoadMatrixd( scene->projectionMatrix ); // we load a matrix of Doubles
+    glLoadMatrixf( scene->projectionMatrix ); // we load a matrix of Doubles
 
     if ( (WIDTH==0) || (HEIGHT==0) ) { fprintf(stderr,"Null dimensions for viewport"); }
     glViewport(0,0,WIDTH,HEIGHT);
@@ -188,7 +188,7 @@ int updateProjectionMatrix()
    int viewport[4]={0};
 
    fprintf(stderr,"Using intrinsics to build projection matrix\n");
-   buildOpenGLProjectionForIntrinsics_OpenGLColumnMajorD   (
+   buildOpenGLProjectionForIntrinsics_OpenGLColumnMajor(
                                              scene->customProjectionMatrix  ,
                                              viewport ,
                                              scene->cameraMatrix[0],
@@ -714,9 +714,9 @@ int setupSceneCameraBeforeRendering(struct VirtualStream * scene)
   if ( (scene!=0) && ( scene->modelViewMatrixDeclared ) )
   {
      //Scene configuration overwrites local configuration
-     glLoadMatrixd( scene->modelViewMatrix ); // we load a matrix of Doubles
+     glLoadMatrixf( scene->modelViewMatrix ); // we load a matrix of Doubles
 
-     copy4x4DMatrix(scene->activeModelViewMatrix , scene->modelViewMatrix);
+     copy4x4FMatrix(scene->activeModelViewMatrix , scene->modelViewMatrix);
       if (scene->useCustomModelViewMatrix)
          {
            fprintf(stderr,"Please not that the model view matrix has been overwritten by the scene configuration parameter\n");
@@ -731,8 +731,8 @@ int setupSceneCameraBeforeRendering(struct VirtualStream * scene)
   if ( (scene!=0) && (scene->useCustomModelViewMatrix) )
   {
     //We load the matrix produced by convertRodriguezAndTranslationToOpenGL4x4DMatrix
-    copy4x4DMatrix(scene->activeModelViewMatrix , scene->customModelViewMatrix);
-    glLoadMatrixd((const GLdouble*) scene->customModelViewMatrix);
+    copy4x4FMatrix(scene->activeModelViewMatrix , scene->customModelViewMatrix);
+    glLoadMatrixf((const GLfloat*) scene->customModelViewMatrix);
 
     /* We flip our coordinate system so it comes straight
        glRotatef(90,-1.0,0,0); //TODO FIX THESE
@@ -759,9 +759,9 @@ int setupSceneCameraBeforeRendering(struct VirtualStream * scene)
                                                 scene->cameraPose.posZ
                                                );
                                                
-    copy4x4FMatrixTo4x4D(scene->activeModelViewMatrix,aMVM.m); 
-    transpose4x4DMatrix(scene->activeModelViewMatrix);
-    glLoadMatrixd(scene->activeModelViewMatrix);
+    copy4x4FMatrix(scene->activeModelViewMatrix,aMVM.m); 
+    transpose4x4FMatrix(scene->activeModelViewMatrix);
+    glLoadMatrixf(scene->activeModelViewMatrix);
 
     /*
     glLoadIdentity();

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Scene/scene.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/Scene/scene.h
@@ -26,9 +26,9 @@ int sceneSeekTime(unsigned int seekTime);
 int sceneIgnoreTime(unsigned int newSettingMode);
 
 
-int sceneSetOpenGLExtrinsicCalibration(struct VirtualStream * scene, double * rodriguez,double * translation , double scaleToDepthUnit);
+int sceneSetOpenGLExtrinsicCalibration(struct VirtualStream * scene,float * rodriguez,float * translation ,float scaleToDepthUnit);
 
-int sceneSetOpenGLIntrinsicCalibration(struct VirtualStream * scene,double * camera);
+int sceneSetOpenGLIntrinsicCalibration(struct VirtualStream * scene,float * camera);
 
 
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/System/CMakeLists.txt
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/System/CMakeLists.txt
@@ -1,0 +1,33 @@
+project( GLXTests ) 
+cmake_minimum_required( VERSION 2.8.7 )
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules ${CMAKE_MODULE_PATH})
+   
+
+add_definitions(-DUSE_GLEW)
+ 
+  
+add_executable(gl3 glx_test.c glx3.c ../Rendering/ShaderPipeline/shader_loader.c ../../../../../tools/AmMatrix/matrix4x4Tools.c ../../../../../tools/AmMatrix/matrixOpenGL.c)
+target_link_libraries(gl3 rt m GL GLU GLEW X11)  
+set_target_properties(gl3 PROPERTIES 
+                       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                      )
+
+add_executable(gl3Tex glx_test.c glx3.c ../Rendering/ShaderPipeline/shader_loader.c ../../../../../tools/AmMatrix/matrix4x4Tools.c ../../../../../tools/AmMatrix/matrixOpenGL.c)
+target_link_libraries(gl3Tex rt m GL GLU GLEW X11)  
+set_target_properties(gl3Tex PROPERTIES 
+                       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                      )
+
+
+add_executable(gl3Multi glx3.c glx_testMultiViewport.c ../Rendering/ShaderPipeline/shader_loader.c ../Rendering/ShaderPipeline/render_buffer.c ../Rendering/ShaderPipeline/uploadGeometry.c ../Rendering/downloadFromRenderer.c  ../Rendering/ShaderPipeline/computeShader.c  ../Rendering/ShaderPipeline/uploadTextures.c ../ModelLoader/model_loader_tri.c ../Tools/save_to_file.c ../Tools/tools.c ../../../../../tools/AmMatrix/matrix4x4Tools.c ../../../../../tools/AmMatrix/matrixOpenGL.c )
+target_link_libraries(gl3Multi rt m GL GLU GLEW X11)  
+set_target_properties(gl3Multi PROPERTIES 
+                       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                      )
+

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/System/CMakeLists.txt
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/System/CMakeLists.txt
@@ -3,6 +3,13 @@ cmake_minimum_required( VERSION 2.8.7 )
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules ${CMAKE_MODULE_PATH})
    
 
+#You need to compile the main RGBDAcquisition project to get these 2 files..
+ADD_LIBRARY(RGBDAcquisitionLibrary SHARED IMPORTED) 
+SET_TARGET_PROPERTIES(RGBDAcquisitionLibrary PROPERTIES IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/../../../../../acquisition/libRGBDAcquisition.so") 
+
+ADD_LIBRARY(CalibrationLibrary STATIC IMPORTED)
+SET_TARGET_PROPERTIES(CalibrationLibrary PROPERTIES IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/../../../../../tools/Calibration/libCalibrationLibrary.a")  
+
 add_definitions(-DUSE_GLEW)
  
   
@@ -26,6 +33,16 @@ set_target_properties(gl3Tex PROPERTIES
 add_executable(gl3Multi glx3.c glx_testMultiViewport.c ../Rendering/ShaderPipeline/shader_loader.c ../Rendering/ShaderPipeline/render_buffer.c ../Rendering/ShaderPipeline/uploadGeometry.c ../Rendering/downloadFromRenderer.c  ../Rendering/ShaderPipeline/computeShader.c  ../Rendering/ShaderPipeline/uploadTextures.c ../ModelLoader/model_loader_tri.c ../Tools/save_to_file.c ../Tools/tools.c ../../../../../tools/AmMatrix/matrix4x4Tools.c ../../../../../tools/AmMatrix/matrixOpenGL.c )
 target_link_libraries(gl3Multi rt m GL GLU GLEW X11)  
 set_target_properties(gl3Multi PROPERTIES 
+                       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                      )
+
+
+
+add_executable(gl3MultiDiff glx3.c glx_testMultiViewportDiff.c ../Rendering/ShaderPipeline/shader_loader.c ../Rendering/ShaderPipeline/render_buffer.c ../Rendering/ShaderPipeline/uploadGeometry.c ../Rendering/downloadFromRenderer.c ../Rendering/ShaderPipeline/computeShader.c  ../Rendering/ShaderPipeline/uploadTextures.c  ../ModelLoader/model_loader_tri.c ../Tools/save_to_file.c ../Tools/tools.c ../../../../../tools/AmMatrix/matrix4x4Tools.c ../../../../../tools/AmMatrix/quaternions.h  ../../../../../tools/AmMatrix/matrixOpenGL.c )
+target_link_libraries(gl3MultiDiff rt m GL GLU GLEW X11 RGBDAcquisitionLibrary CalibrationLibrary)  
+set_target_properties(gl3MultiDiff PROPERTIES 
                        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
                        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/System/glx_test.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/System/glx_test.c
@@ -477,13 +477,13 @@ int doDrawing()
 
 
 
-     double projectionMatrixD[16];
-     double viewportMatrixD[16];
-     double viewMatrixD[16];
+     struct Matrix4x4OfFloats projectionMatrix;
+     struct Matrix4x4OfFloats viewportMatrix;
+     struct Matrix4x4OfFloats viewMatrix;
      prepareMatrices(
-                     projectionMatrixD,
-                     viewMatrixD,
-                     viewportMatrixD
+                     &projectionMatrix,
+                     &viewMatrix,
+                     &viewportMatrix
                     );
 
 
@@ -564,9 +564,9 @@ int doDrawing()
                   pitch,
                   yaw,
 
-                  projectionMatrixD,
-                  viewportMatrixD,
-                  viewMatrixD
+                  &projectionMatrix,
+                  &viewportMatrix,
+                  &viewMatrix
                  );
 
 
@@ -582,9 +582,9 @@ int doDrawing()
                   pitch,
                   yaw,
 
-                  projectionMatrixD,
-                  viewportMatrixD,
-                  viewMatrixD
+                  &projectionMatrix,
+                  &viewportMatrix,
+                  &viewMatrix
                  );
 
 		// Swap buffers

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/System/glx_testMultiViewport.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/System/glx_testMultiViewport.c
@@ -33,7 +33,7 @@
 
 
 
-#define NORMAL   "\033[0m"
+#define NORMAL  "\033[0m"
 #define BLACK   "\033[30m"      /* Black */
 #define RED     "\033[31m"      /* Red */
 
@@ -173,10 +173,10 @@ int doTiledDrawing(
                      535.423889, //fx
                      533.48468,  //fy
                      0.0,        //skew
-                     (double) originalWIDTH/2,    //cx
-                     (double) originalHEIGHT/2,   //cy
-                     (double) originalWIDTH,      //Window Width
-                     (double) originalHEIGHT,     //Window Height
+                     (float) originalWIDTH/2,    //cx
+                     (float) originalHEIGHT/2,   //cy
+                     (float) originalWIDTH,      //Window Width
+                     (float) originalHEIGHT,     //Window Height
                      1.0,        //Near
                      255.0,      //Far
                      &projectionMatrix,
@@ -185,13 +185,13 @@ int doTiledDrawing(
                     );
 
      //-------------------------------------------------------------------
-        double roll=0.0;//(double)  (rand()%90);
-        double pitch=0.0;//(double) (rand()%90);
-        double yaw=0.0;//(double)   (rand()%90);
+        float roll=0.0;//(float)  (rand()%90);
+        float pitch=0.0;//(float) (rand()%90);
+        float yaw=0.0;//(float)   (rand()%90);
 
-        double x=-259.231f;//(double)  (1000-rand()%2000);
-        double y=-54.976f;//(double) (100-rand()%200);
-        double z=2699.735f;//(double)  (700+rand()%1000);
+        float x=-259.231f;//(float)  (1000-rand()%2000);
+        float y=-54.976f;//(float) (100-rand()%200);
+        float z=2699.735f;//(float)  (700+rand()%1000);
      //-------------------------------------------------------------------
 
   unsigned int viewportWidth = (unsigned int) WIDTH / tilesX;
@@ -290,13 +290,13 @@ int doSingleDrawing(
 
 
      //-------------------------------------------------------------------
-        double roll=0.0;//(double)  (rand()%90);
-        double pitch=0.0;//(double) (rand()%90);
-        double yaw=0.0;//(double)   (rand()%90);
+        float roll=0.0;//(float)  (rand()%90);
+        float pitch=0.0;//(float) (rand()%90);
+        float yaw=0.0;//(float)   (rand()%90);
 
-        double x=-259.231f;//(double)  (1000-rand()%2000);
-        double y=-54.976f;//(double) (100-rand()%200);
-        double z=2699.735f;//(double)  (700+rand()%1000);
+        float x=-259.231f;//(float)  (1000-rand()%2000);
+        float y=-54.976f;//(float) (100-rand()%200);
+        float z=2699.735f;//(float)  (700+rand()%1000);
      //-------------------------------------------------------------------
      //fprintf(stderr,"glViewport(%u,%u,%u,%u)\n",viewportWidth*tx, viewportHeight*ty, viewportWidth , viewportHeight);
      drawObjectAT(

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryCalculator.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryCalculator.c
@@ -59,8 +59,8 @@ int printObjectTrajectory(struct VirtualStream * stream,unsigned int ObjID,unsig
     if (!accessOfObjectPositionIsOk(stream,ObjID,FrameIDToReturn)) { return 0; }
 
     fprintf(stderr,"printObjectTrajectory quaternions are qXqYqZqW\n");
-    double euler[3];
-    double quaternions[4];
+    float euler[3];
+    float quaternions[4];
 
     fprintf(stderr,"POS=\"%0.2f %0.2f %0.2f\"\n",
             stream->object[ObjID].frame[FrameIDToReturn].x,
@@ -111,7 +111,7 @@ int rotatePositionOfObjectTrajectory(struct VirtualStream * stream,unsigned int 
    if ( stream->object[ObjID].frame[FrameIDToReturn].isQuaternion )
    {
        fprintf(stderr,"rotatePositionOfObjectTrajectory doing a quaternion rotation %0.2f %0.2f %0.2f , angle %0.2f..\n",*x,*y,*z,*angleDegrees);
-       double quaternion[4]={0};
+       float quaternion[4]={0};
        quaternion[0]=stream->object[ObjID].frame[FrameIDToReturn].rot1;
        quaternion[1]=stream->object[ObjID].frame[FrameIDToReturn].rot2;
        quaternion[2]=stream->object[ObjID].frame[FrameIDToReturn].rot3;
@@ -194,14 +194,14 @@ float calculateDistanceTra(float from_x,float from_y,float from_z,float to_x,flo
 
 }
 
-void euler2QuaternionsInternal(double * quaternions,double * euler,int quaternionConvention)
+void euler2QuaternionsInternal(float * quaternions,float * euler,int quaternionConvention)
 {
   #warning "TODO : make this use euler2Quaternions declared at AmMatrix/quaternions.h"
   //This conversion follows the rule euler X Y Z  to quaternions W X Y Z
   //Our input is degrees so we convert it to radians for the sin/cos functions
-  double eX = (double) (euler[0] * PI) / 180;
-  double eY = (double) (euler[1] * PI) / 180;
-  double eZ = (double) (euler[2] * PI) / 180;
+  float eX = (float) (euler[0] * PI) / 180;
+  float eY = (float) (euler[1] * PI) / 180;
+  float eZ = (float) (euler[2] * PI) / 180;
 
   //fprintf(stderr,"eX %f eY %f eZ %f\n",eX,eY,eZ);
 
@@ -210,12 +210,12 @@ void euler2QuaternionsInternal(double * quaternions,double * euler,int quaternio
   //eY Pitch θ - rotation about the Y-axis
   //eZ Yaw   ψ - rotation about the Z-axis
 
-  double cosX2 = cos((double) eX/2); //cos(φ/2);
-  double sinX2 = sin((double) eX/2); //sin(φ/2);
-  double cosY2 = cos((double) eY/2); //cos(θ/2);
-  double sinY2 = sin((double) eY/2); //sin(θ/2);
-  double cosZ2 = cos((double) eZ/2); //cos(ψ/2);
-  double sinZ2 = sin((double) eZ/2); //sin(ψ/2);
+  float cosX2 = cos((float) eX/2); //cos(φ/2);
+  float sinX2 = sin((float) eX/2); //sin(φ/2);
+  float cosY2 = cos((float) eY/2); //cos(θ/2);
+  float sinY2 = sin((float) eY/2); //sin(θ/2);
+  float cosZ2 = cos((float) eZ/2); //cos(ψ/2);
+  float sinZ2 = sin((float) eZ/2); //sin(ψ/2);
 
   switch (quaternionConvention )
   {
@@ -240,10 +240,10 @@ void euler2QuaternionsInternal(double * quaternions,double * euler,int quaternio
 
 }
 
-int convertQuaternionsToEulerAngles(struct VirtualStream * stream,double * euler,double *quaternion)
+int convertQuaternionsToEulerAngles(struct VirtualStream * stream,float * euler,float *quaternion)
 {
  normalizeQuaternions(&quaternion[0],&quaternion[1],&quaternion[2],&quaternion[3]);
- double eulerTMP[3];
+ float eulerTMP[3];
  quaternions2Euler(eulerTMP,quaternion,1); //1
  euler[0] = stream->rotationsOffset[0] + (stream->scaleWorld[3] * eulerTMP[0]);
  euler[1] = stream->rotationsOffset[1] + (stream->scaleWorld[4] * eulerTMP[1]);
@@ -261,12 +261,12 @@ int convertQuaternionsToEulerAngles(struct VirtualStream * stream,double * euler
  return 1;
 }
 
-int parseAbsoluteRotation(struct VirtualStream * stream,double * planetRotAbsolute,unsigned int planetObj,unsigned int frameNumber)
+int parseAbsoluteRotation(struct VirtualStream * stream,float * planetRotAbsolute,unsigned int planetObj,unsigned int frameNumber)
 {
    if (stream->object[planetObj].frame[frameNumber].isQuaternion)
       {
-        double euler[3];
-        double quaternions[4];
+        float euler[3];
+        float quaternions[4];
         quaternions[0]=stream->object[planetObj].frame[frameNumber].rot1;
         quaternions[1]=stream->object[planetObj].frame[frameNumber].rot2;
         quaternions[2]=stream->object[planetObj].frame[frameNumber].rot3;
@@ -277,9 +277,9 @@ int parseAbsoluteRotation(struct VirtualStream * stream,double * planetRotAbsolu
         planetRotAbsolute[2] = euler[2];
       } else
       {
-       planetRotAbsolute[0] = (double) stream->object[planetObj].frame[frameNumber].rot1;
-       planetRotAbsolute[1] = (double) stream->object[planetObj].frame[frameNumber].rot2;
-       planetRotAbsolute[2] = (double) stream->object[planetObj].frame[frameNumber].rot3;
+       planetRotAbsolute[0] = (float) stream->object[planetObj].frame[frameNumber].rot1;
+       planetRotAbsolute[1] = (float) stream->object[planetObj].frame[frameNumber].rot2;
+       planetRotAbsolute[2] = (float) stream->object[planetObj].frame[frameNumber].rot3;
       }
   return 1;
 }
@@ -339,38 +339,38 @@ int affixSatteliteToPlanetFromFrameForLength(struct VirtualStream * stream,unsig
 
     //There is literally no good reason to go from rotation -> quaternion -> 3x3 -> quaternion -> rotation this could be optimized
     //==================================================================================
-    double satPosAbsolute[4]={0};
-    satPosAbsolute[0] = (double) stream->object[satteliteObj].frame[frameNumber].x;
-    satPosAbsolute[1] = (double) stream->object[satteliteObj].frame[frameNumber].y;
-    satPosAbsolute[2] = (double) stream->object[satteliteObj].frame[frameNumber].z;
+    float satPosAbsolute[4]={0};
+    satPosAbsolute[0] = (float) stream->object[satteliteObj].frame[frameNumber].x;
+    satPosAbsolute[1] = (float) stream->object[satteliteObj].frame[frameNumber].y;
+    satPosAbsolute[2] = (float) stream->object[satteliteObj].frame[frameNumber].z;
     satPosAbsolute[3] = 1.0;
     //==================================================================================
-    double planetPosAbsolute[4]={0};
-    planetPosAbsolute[0] = (double) stream->object[planetObj].frame[frameNumber].x;
-    planetPosAbsolute[1] = (double) stream->object[planetObj].frame[frameNumber].y;
-    planetPosAbsolute[2] = (double) stream->object[planetObj].frame[frameNumber].z;
+    float planetPosAbsolute[4]={0};
+    planetPosAbsolute[0] = (float) stream->object[planetObj].frame[frameNumber].x;
+    planetPosAbsolute[1] = (float) stream->object[planetObj].frame[frameNumber].y;
+    planetPosAbsolute[2] = (float) stream->object[planetObj].frame[frameNumber].z;
     planetPosAbsolute[3] = 1.0;
 
-    double planetRotAbsolute[4]={0};
-    planetRotAbsolute[0] = (double) stream->object[planetObj].frame[frameNumber].rot1;
-    planetRotAbsolute[1] = (double) stream->object[planetObj].frame[frameNumber].rot2;
-    planetRotAbsolute[2] = (double) stream->object[planetObj].frame[frameNumber].rot3;
+    float planetRotAbsolute[4]={0};
+    planetRotAbsolute[0] = (float) stream->object[planetObj].frame[frameNumber].rot1;
+    planetRotAbsolute[1] = (float) stream->object[planetObj].frame[frameNumber].rot2;
+    planetRotAbsolute[2] = (float) stream->object[planetObj].frame[frameNumber].rot3;
 
 
     parseAbsoluteRotation(stream,planetRotAbsolute,planetObj,frameNumber);
     //==================================================================================
 
 
-    double satPosRelative[4]={0};
+    float satPosRelative[4]={0};
     pointFromAbsoluteToRelationWithObject_PosXYZRotationXYZ(satPosRelative,planetPosAbsolute,planetRotAbsolute,satPosAbsolute);
 
     unsigned int pos=0;
     fprintf(stderr,YELLOW " Will align satelite to planet from frame %u to %u\n" NORMAL ,frameNumber+1 , frameNumber+duration );
     for (pos=frameNumber+1; pos<frameNumber+duration; pos++)
     {
-       planetPosAbsolute[0] = (double) stream->object[planetObj].frame[pos].x;
-       planetPosAbsolute[1] = (double) stream->object[planetObj].frame[pos].y;
-       planetPosAbsolute[2] = (double) stream->object[planetObj].frame[pos].z;
+       planetPosAbsolute[0] = (float) stream->object[planetObj].frame[pos].x;
+       planetPosAbsolute[1] = (float) stream->object[planetObj].frame[pos].y;
+       planetPosAbsolute[2] = (float) stream->object[planetObj].frame[pos].z;
        planetPosAbsolute[3] = 1.0;
 
        parseAbsoluteRotation(stream,planetRotAbsolute,planetObj,frameNumber);
@@ -414,16 +414,16 @@ int objectsCollide(struct VirtualStream * newstream,unsigned int atTime,unsigned
   return 1;
 }
 
-int flipRotationAxisD(double * rotX, double * rotY , double * rotZ , int where2SendX , int where2SendY , int where2SendZ)
+int flipRotationAxisD(float * rotX, float * rotY , float * rotZ , int where2SendX , int where2SendY , int where2SendZ)
 {
   #if PRINT_LOAD_INFO
    fprintf(stderr,"Had rotX %f rotY %f rotZ %f \n",*rotX,*rotY,*rotZ);
    fprintf(stderr,"Moving 0 to %u , 1 to %u , 2 to %u \n",where2SendX,where2SendY,where2SendZ);
   #endif
 
-  double tmpX = *rotX;
-  double tmpY = *rotY;
-  double tmpZ = *rotZ;
+  float tmpX = *rotX;
+  float tmpY = *rotY;
+  float tmpZ = *rotZ;
   //-----------------------------------------
   if (where2SendX==0) { *rotX=tmpX; } else
   if (where2SendX==1) { *rotY=tmpX; } else
@@ -639,7 +639,7 @@ int fillPosWithFrame(
 
        struct Matrix4x4OfFloats mF={0};
          
-       double rotCur[4]={0};
+       float rotCur[4]={0};
        unsigned int i=0,z=0;
        for (i=0; i<numberOfJoints; i++)
        {
@@ -799,9 +799,9 @@ int fillJointsWithInterpolatedFrame(
          
          create4x4FMatrixFromEulerAnglesWithRotationOrder(
                                                           &mF,
-                                                          (double) rotTot[0],
-                                                          (double) rotTot[1],
-                                                          (double) rotTot[2],
+                                                          (float) rotTot[0],
+                                                          (float) rotTot[1],
+                                                          (float) rotTot[2],
                                                           (unsigned int) stream->object[ObjID].frame[NextFrame].jointList->joint[i].eulerRotationOrder
                                                         );
          //create4x4MatrixFromEulerAnglesXYZ(m,rotTot[0],rotTot[1],rotTot[2]);

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryCalculator.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryCalculator.c
@@ -814,7 +814,7 @@ int fillJointsWithInterpolatedFrame(
           )
         {
         //fprintf(stderr,"Rotation MAT4x4 (obj=%u pos=%u bone=%u ) \n",ObjID,PrevFrame,i);
-        slerp2RotTransMatrices4x4F(
+        slerp2RotTransMatrices4x4(
                                    f , //write straight to the output
                                    stream->object[ObjID].frame[PrevFrame].jointList->joint[i].m,
                                    stream->object[ObjID].frame[NextFrame].jointList->joint[i].m ,

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryCalculator.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryCalculator.h
@@ -17,18 +17,18 @@ int rotatePositionOfObjectTrajectory(struct VirtualStream * stream,unsigned int 
 int smoothTrajectoriesOfObject(struct VirtualStream * stream,unsigned int ObjID);
 int smoothTrajectories(struct VirtualStream * stream);
 float calculateDistanceTra(float from_x,float from_y,float from_z,float to_x,float to_y,float to_z);
-void euler2QuaternionsInternal(double * quaternions,double * euler,int quaternionConvention);
+void euler2QuaternionsInternal(float * quaternions,float * euler,int quaternionConvention);
 int affixSatteliteToPlanetFromFrameForLength(struct VirtualStream * stream,unsigned int satteliteObj,unsigned int planetObj , unsigned int frameNumber , unsigned int duration);
 int objectsCollide(struct VirtualStream * newstream,unsigned int atTime,unsigned int objIDA,unsigned int objIDB);
 
-int flipRotationAxisD(double * rotX, double * rotY , double * rotZ , int where2SendX , int where2SendY , int where2SendZ);
+int flipRotationAxisD(float * rotX, float * rotY , float * rotZ , int where2SendX , int where2SendY , int where2SendZ);
 int flipRotationAxis(float * rotX, float * rotY , float * rotZ , int where2SendX , int where2SendY , int where2SendZ);
 int unflipRotationAxis(float * rotX, float * rotY , float * rotZ , int where2SendX , int where2SendY , int where2SendZ);
 
 
 
 
-int convertQuaternionsToEulerAngles(struct VirtualStream * stream,double * euler,double *quaternion);
+int convertQuaternionsToEulerAngles(struct VirtualStream * stream,float * euler,float *quaternion);
 
 
 
@@ -37,7 +37,7 @@ int convertQuaternionsToEulerAngles(struct VirtualStream * stream,double * euler
 int fillPosWithNull(float * pos,float * scaleX ,float * scaleY,float * scaleZ);
 int fillPosWithLastFrame(struct VirtualStream * stream,ObjectIDHandler ObjID,float * pos,float * joints,float * scaleX,float * scaleY,float * scaleZ );
 /*
-int fillPosWithLastFrameD(struct VirtualStream * stream,ObjectIDHandler ObjID,double * pos,double * scale )
+int fillPosWithLastFrameD(struct VirtualStream * stream,ObjectIDHandler ObjID,float * pos,float * scale )
 */
 
 

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryParser.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryParser.c
@@ -145,8 +145,8 @@ int processCommand( struct VirtualStream * newstream , struct ModelList * modelS
   char model[MAX_PATH]={0};
   char typeStr[MAX_PATH]={0};
   char includeFile[MAX_PATH]={0};
-  double euler[3];
-  double quaternions[4];
+  float euler[3];
+  float quaternions[4];
   float pos[16]={0};
   unsigned int i,satteliteObj,planetObj,item,frame,duration,time,coordLength,eventType=0,foundA=0,foundB=0,objIDA=0,objIDB=0;
 
@@ -252,21 +252,21 @@ int processCommand( struct VirtualStream * newstream , struct ModelList * modelS
 
            case TRAJECTORYPRIMITIVES_PROJECTION_MATRIX :
                  newstream->projectionMatrixDeclared=1;
-                 for (i=1; i<=16; i++) { newstream->projectionMatrix[i-1] = (double)  InputParser_GetWordFloat(ipc,i); }
+                 for (i=1; i<=16; i++) { newstream->projectionMatrix[i-1] = (float)  InputParser_GetWordFloat(ipc,i); }
                  fprintf(stderr,"Projection Matrix given to TrajectoryParser\n");
            break;
 
 
            case TRAJECTORYPRIMITIVES_EMULATE_PROJECTION_MATRIX :
                  newstream->emulateProjectionMatrixDeclared=1;
-                 for (i=1; i<=9; i++) { newstream->emulateProjectionMatrix[i-1] = (double)  InputParser_GetWordFloat(ipc,i); }
+                 for (i=1; i<=9; i++) { newstream->emulateProjectionMatrix[i-1] = (float)  InputParser_GetWordFloat(ipc,i); }
                  fprintf(stderr,"Emulating Projection Matrix given to TrajectoryParser\n");
            break;
 
 
            case TRAJECTORYPRIMITIVES_MODELVIEW_MATRIX :
                  newstream->modelViewMatrixDeclared=1;
-                 for (i=1; i<=16; i++) { newstream->modelViewMatrix[i-1] = (double) InputParser_GetWordFloat(ipc,i); }
+                 for (i=1; i<=16; i++) { newstream->modelViewMatrix[i-1] = (float) InputParser_GetWordFloat(ipc,i); }
                  fprintf(stderr,"ModelView Matrix given to TrajectoryParser\n");
            break;
 
@@ -622,8 +622,8 @@ int processCommand( struct VirtualStream * newstream , struct ModelList * modelS
 
                int coordLength=7;
 
-               double euler[3];
-               double quaternions[4]; quaternions[0]=pos[3]; quaternions[1]=pos[4]; quaternions[2]=pos[5]; quaternions[3]=pos[6];
+               float euler[3];
+               float quaternions[4]; quaternions[0]=pos[3]; quaternions[1]=pos[4]; quaternions[2]=pos[5]; quaternions[3]=pos[6];
 
                normalizeQuaternions(&quaternions[0],&quaternions[1],&quaternions[2],&quaternions[3]);
                quaternions2Euler(euler,quaternions,1); //1
@@ -706,8 +706,8 @@ int processCommand( struct VirtualStream * newstream , struct ModelList * modelS
                pos[5] = InputParser_GetWordFloat(ipc,6);
                pos[6] = InputParser_GetWordFloat(ipc,7);
 
-               double euler[3];
-               double quaternions[4]; quaternions[0]=pos[3]; quaternions[1]=pos[4]; quaternions[2]=pos[5]; quaternions[3]=pos[6];
+               float euler[3];
+               float quaternions[4]; quaternions[0]=pos[3]; quaternions[1]=pos[4]; quaternions[2]=pos[5]; quaternions[3]=pos[6];
 
                normalizeQuaternions(&quaternions[0],&quaternions[1],&quaternions[2],&quaternions[3]);
                quaternions2Euler(euler,quaternions,1); //1

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryParser.h
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/TrajectoryParser/TrajectoryParser.h
@@ -161,8 +161,7 @@ struct VirtualConnector
 
    float R , G , B , Transparency;
 
-   double scale;
-
+   float scale; 
 };
 
 
@@ -196,7 +195,7 @@ struct VirtualObject
    unsigned int lastFrameTime;
    unsigned int nextFrameTime;
 
-   double scaleX,scaleY,scaleZ;
+   float scaleX,scaleY,scaleZ;
    unsigned int particleNumber;
 
    unsigned int bbox2D[4];
@@ -209,7 +208,7 @@ struct VirtualObject
    // 0-6  low bounds          X Y Z    A B C D
    // 7-13 high bounds         X Y Z    A B C D
    // 14-20 resample variances X Y Z    A B C D
-   double limits[ 7 * 3];
+   float limits[ 7 * 3];
 
    unsigned int generations;
    unsigned int particles;*/
@@ -247,7 +246,6 @@ struct VirtualStreamControls
   //float depthUnit = 1.0;
 
   unsigned int userKeyFOVEnabled;
-
 };
 
 
@@ -261,10 +259,10 @@ struct VirtualStream
     // These are the matrices actively used by OpenGL
     // to render the scene
     //--------------------------------------------------------
-     double activeProjectionMatrix[16];
-     double activeModelViewMatrix[16];
-     double activeModelViewProjectionMatrix[16];
-     double activeNormalTransformation[16];
+     float activeProjectionMatrix[16];
+     float activeModelViewMatrix[16];
+     float activeModelViewProjectionMatrix[16];
+     float activeNormalTransformation[16];
     //--------------------------------------------------------
     //--------------------------------------------------------
 
@@ -273,27 +271,27 @@ struct VirtualStream
     // control the view of the camera for our scene
     //--------------------------------------------------------
     int projectionMatrixDeclared;
-    double projectionMatrix[16];
+    float projectionMatrix[16];
 
     int modelViewMatrixDeclared;
-    double modelViewMatrix[16];
+    float modelViewMatrix[16];
 
 
     int useCustomProjectionMatrix;
-    double customProjectionMatrix[16];
+    float customProjectionMatrix[16];
 
     int useCustomModelViewMatrix;
-    double customModelViewMatrix[16];
+    float customModelViewMatrix[16];
 
     int emulateProjectionMatrixDeclared;
-    double emulateProjectionMatrix[9];
+    float emulateProjectionMatrix[9];
 
     int extrinsicsDeclared;
-    double extrinsicTranslation[3];
-    double extrinsicRodriguezRotation[3];
+    float extrinsicTranslation[3];
+    float extrinsicRodriguezRotation[3];
 
     int useIntrinsicMatrix;
-    double cameraMatrix[9];
+    float cameraMatrix[9];
     //--------------------------------------------------------
     //--------------------------------------------------------
     //--------------------------------------------------------
@@ -346,7 +344,7 @@ struct VirtualStream
     struct ModelList * associatedModelList;
     void * modelStorage;
 
-    double scaleWorld[6];
+    float scaleWorld[6];
     int rotationsOverride;
     int rotationsXYZ[3];
     float rotationsOffset[3];

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/main.c
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/src/Library/main.c
@@ -145,31 +145,31 @@ void redraw(void)
 }
 
 
-int setOpenGLNearFarPlanes(double near , double far)
+int setOpenGLNearFarPlanes(float near ,float far)
 {
  return sceneSetNearFarPlanes((float) near, (float) far);
 }
 
-int setOpenGLIntrinsicCalibration(double * camera)
+int setOpenGLIntrinsicCalibration(float * camera)
 {
   return sceneSetOpenGLIntrinsicCalibration(getLoadedScene(),camera);
 }
 
 
-int setOpenGLExtrinsicCalibration(double * rodriguez,double * translation , double scaleToDepthUnit)
+int setOpenGLExtrinsicCalibration(float * rodriguez,float * translation , float scaleToDepthUnit)
 {
   return sceneSetOpenGLExtrinsicCalibration(getLoadedScene(),rodriguez,translation,scaleToDepthUnit);
 }
 
 
-double getOpenGLFocalLength()
+float getOpenGLFocalLength()
 {
  return sceneGetNearPlane();
 }
 
-double getOpenGLPixelSize()
+float getOpenGLPixelSize()
 {
- return 2/WIDTH;
+ return (float) 2/WIDTH;
 }
 
 int controlScene(const char * name,const char * variable,int control,float valueA,float valueB,float valueC)

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/submodules/Assimp/CMakeLists.txt
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/submodules/Assimp/CMakeLists.txt
@@ -2,7 +2,8 @@ project( assimpLoader )
 cmake_minimum_required( VERSION 2.8.7 )  
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules ${CMAKE_MODULE_PATH})
   
- 
+
+message("Don't foget to sudo apt-get install libassimp-dev")
  
 add_library(assimpLoader SHARED  
             assimp_loader.cpp

--- a/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/submodules/Assimp/assimp_loader.cpp
+++ b/opengl_acquisition_shared_library/opengl_depth_and_color_renderer/submodules/Assimp/assimp_loader.cpp
@@ -52,7 +52,7 @@ void aiMakeQuaternion(aiMatrix4x4 * am , aiQuaternion * qu)
 }
 
 
-void doubleMatMakeIdentity(double * am)
+void floatMatMakeIdentity(float * am)
 {
  am[0] = 1.0; am[1] = 0.0;  am[2] = 0.0;  am[3] = 0.0;
  am[4] = 0.0; am[5] = 1.0;  am[6] = 0.0;  am[7] = 0.0;
@@ -154,7 +154,7 @@ unsigned int countNumberOfNodes(struct aiScene *scene  , struct aiMesh * mesh )
   return numberOfNodes;
 }
 
-void convertMatrixAIToAmMatrix(double * rm ,  aiMatrix4x4 * am)
+void convertMatrixAIToAmMatrix(float * rm ,  aiMatrix4x4 * am)
 {
  rm[0]=am->a1; rm[1]=am->a2;  rm[2]=am->a3;  rm[3]=am->a4;
  rm[4]=am->b1; rm[5]=am->b2;  rm[6]=am->b3;  rm[7]=am->b4;
@@ -177,7 +177,7 @@ void fillInNodeAndBoneData(struct aiNode *node ,  struct aiMesh * mesh , unsigne
 
 
   //Make sure that the finalVertexTransformation is identity , so it will always make sense..
-  double * d = triModel->bones[nodeNum].info->finalVertexTransformation;
+  float * d = triModel->bones[nodeNum].info->finalVertexTransformation;
   d[0]=1.0;  d[1]=0.0;  d[2]=0.0;  d[3]=0.0;
   d[4]=0.0;  d[5]=1.0;  d[6]=0.0;  d[7]=0.0;
   d[8]=0.0;  d[9]=0.0;  d[10]=1.0; d[11]=0.0;
@@ -226,8 +226,8 @@ void fillInNodeAndBoneData(struct aiNode *node ,  struct aiMesh * mesh , unsigne
 
 
    convertMatrixAIToAmMatrix(triModel->bones[nodeNum].info->localTransformation,  &node->mTransformation);
-   doubleMatMakeIdentity(triModel->bones[nodeNum].info->finalVertexTransformation);
-   doubleMatMakeIdentity(triModel->bones[nodeNum].info->matrixThatTransformsFromMeshSpaceToBoneSpaceInBindPose);
+   floatMatMakeIdentity(triModel->bones[nodeNum].info->finalVertexTransformation);
+   floatMatMakeIdentity(triModel->bones[nodeNum].info->matrixThatTransformsFromMeshSpaceToBoneSpaceInBindPose);
 
 
   if (findBoneNumFromAINode( node ,  mesh , &boneNum ))
@@ -340,7 +340,7 @@ void prepareMesh(struct aiScene *scene , int meshNumber , struct TRI_Model * tri
     triModel->header.numberOfIndices       = mesh->mNumFaces*3;       indexSize        =triModel->header.numberOfIndices       * sizeof(unsigned int);
     triModel->header.numberOfBones         = 0;                       //bonesSize        =0; //Initially no bones allocated this will be done later..!
 
-    double * gm = triModel->header.boneGlobalInverseTransform;
+    float * gm = triModel->header.boneGlobalInverseTransform;
     gm[0]=m_GlobalInverseTransform.a1;  gm[1]=m_GlobalInverseTransform.a2;  gm[2]=m_GlobalInverseTransform.a3;  gm[3]=m_GlobalInverseTransform.a4;
     gm[4]=m_GlobalInverseTransform.b1;  gm[5]=m_GlobalInverseTransform.b2;  gm[6]=m_GlobalInverseTransform.b3;  gm[7]=m_GlobalInverseTransform.b4;
     gm[8]=m_GlobalInverseTransform.c1;  gm[9]=m_GlobalInverseTransform.c2;  gm[10]=m_GlobalInverseTransform.c3; gm[11]=m_GlobalInverseTransform.c4;

--- a/tools/AmMatrix/TestCPUOptimizedInstructionSet/main.c
+++ b/tools/AmMatrix/TestCPUOptimizedInstructionSet/main.c
@@ -55,7 +55,7 @@ int main()
         matrixB.m[1] = tmp;
         
         unsigned long startUnoptimized = GetTickCountMicrosecondsMN();
-        multiplyTwo4x4FMatrices(testResultUnoptimized.m,matrixA.m,matrixB.m);
+        multiplyTwo4x4FMatrices_Naive(testResultUnoptimized.m,matrixA.m,matrixB.m);
         unsigned long endUnoptimized = GetTickCountMicrosecondsMN();
         unoptimizedTime+=endUnoptimized - startUnoptimized;
 

--- a/tools/AmMatrix/TestCPUOptimizedInstructionSet/main.c
+++ b/tools/AmMatrix/TestCPUOptimizedInstructionSet/main.c
@@ -32,28 +32,54 @@ int main()
       exit(0);
     }
 
-    int i=0;
-    float __attribute__((aligned(16))) testResultOptimized[16]= {0};
-    float testResultUnoptimized[16]= {0};
-    float __attribute__((aligned(16))) matrixA[16]= {0};
-    float __attribute__((aligned(16))) matrixB[16]= {0};
+    int i=0; 
+    
+    struct Matrix4x4OfFloats testResultOptimized={0};
+    struct Matrix4x4OfFloats testResultUnoptimized={0};
+    struct Matrix4x4OfFloats matrixA={0};
+    struct Matrix4x4OfFloats matrixB={0};
+     
+    //Set matrices to identity
+    matrixA.m[0]=1.0; matrixA.m[5]=1.0; matrixA.m[10]=1.0; matrixA.m[15]=1.0; 
+    matrixB.m[0]=1.0; matrixB.m[5]=1.0; matrixB.m[10]=1.0; matrixB.m[15]=1.0; 
 
-    unsigned int numberOfSamples = 1000;
+    unsigned int numberOfSamples = 100000;
     unsigned long unoptimizedTime = 0;
     unsigned long optimizedTime = 0;
-
+    
+    unsigned int errors = 0;
     for (i=0; i<numberOfSamples; i++)
     {
+        float tmp = rand()%1000 / 100;
+        matrixA.m[1] = tmp;
+        matrixB.m[1] = tmp;
+        
         unsigned long startUnoptimized = GetTickCountMicrosecondsMN();
-        multiplyTwo4x4FMatrices(testResultUnoptimized,matrixA,matrixB);
+        multiplyTwo4x4FMatrices(testResultUnoptimized.m,matrixA.m,matrixB.m);
         unsigned long endUnoptimized = GetTickCountMicrosecondsMN();
         unoptimizedTime+=endUnoptimized - startUnoptimized;
 
         unsigned long startOptimized = GetTickCountMicrosecondsMN();
-        multiplyTwo4x4FMatrices_SSE(testResultOptimized,matrixA,matrixB);
+        multiplyTwo4x4FMatrices_SSE(testResultOptimized.m,matrixA.m,matrixB.m);
         unsigned long endOptimized = GetTickCountMicrosecondsMN();
-        optimizedTime+=endOptimized - startOptimized;
+        optimizedTime+=endOptimized - startOptimized; 
+        
+        if (matrixA.m[1]!=matrixB.m[1])
+        {
+            ++errors;
+        }
     }
+    
+    if (errors>0)
+    {
+        fprintf(stderr,"%u errors encountered..\n",errors);
+    }
+    
+    print4x4FMatrix("Unoptimized Result",testResultUnoptimized.m,1);
+    print4x4FMatrix("Optimized Result",testResultOptimized.m,1);
+
+    
+    printf("Finished with %u samples !\n",numberOfSamples);
     printf("%0.4f microseconds unoptimized!\n",(float) unoptimizedTime/numberOfSamples);
     printf("%0.4f microseconds optimized!\n",(float) optimizedTime/numberOfSamples);
     return 0;

--- a/tools/AmMatrix/matrix3x3Tools.c
+++ b/tools/AmMatrix/matrix3x3Tools.c
@@ -186,7 +186,7 @@ void  create3x3EulerRotationXYZOrthonormalMatrix(double * matrix3x3,double * rot
 
 
 
-int upscale3x3to4x4(double * mat4x4,double * mat3x3)
+int upscale3x3Fto4x4F(float * mat4x4,float * mat3x3)
 {
   if  ( (mat3x3==0)||(mat4x4==0) )   { return 0; }
 

--- a/tools/AmMatrix/matrix3x3Tools.h
+++ b/tools/AmMatrix/matrix3x3Tools.h
@@ -126,7 +126,7 @@ int transpose3x3MatrixDFromSource(double * dest,double * source);
 * @param  Input 3x3 Matrix
 * @retval 0=Failure,1=Success
 */
-int upscale3x3to4x4(double * mat4x4,double * mat3x3);
+int upscale3x3Fto4x4F(float * mat4x4,float * mat3x3);
 
 
 /**

--- a/tools/AmMatrix/matrix4x4Tools.c
+++ b/tools/AmMatrix/matrix4x4Tools.c
@@ -43,19 +43,6 @@ enum mat4x4EItem
 */
 
 
-double * malloc4x4DMatrix()
-{
-  return (double*) malloc ( sizeof(double) * 16 );
-}
-
-void free4x4DMatrix(double ** mat)
-{
-  if (mat==0) { return ; }
-  if (*mat==0) { return ; }
-  free(*mat);
-  *mat=0;
-}
-
 void print4x4FMatrix(const char * str , float * matrix4x4,int forcePrint)
 {
   #if PRINT_MATRIX_DEBUGGING
@@ -93,7 +80,7 @@ void print4x4DMatrix(const char * str , double * matrix4x4,int forcePrint)
 }
 
 
-void print4x4DMathematicaMatrix(const char * str , double * matrix3x3,int forcePrint)
+void print4x4FMathematicaMatrix(const char * str , float * matrix3x3,int forcePrint)
 {
   #if PRINT_MATRIX_DEBUGGING
     forcePrint=1;
@@ -159,70 +146,24 @@ void copy4x4DMatrixTo4x4F(float * dest, double * m )
     dest[12]=(float)m[12]; dest[13]=(float)m[13]; dest[14]=(float)m[14];  dest[15]=(float)m[15];
 }
 
+ 
 
-void create4x4DIdentityMatrix(double * m)
+void create4x4FIdentityMatrix(struct Matrix4x4OfFloats * m)
 {
   #if OPTIMIZED
-   memset(m,0,16*sizeof(double));
-   m[0] = 1.0;
-   m[5] = 1.0;
-   m[10] = 1.0;
-   m[15] = 1.0;
+   memset(m->m,0,16*sizeof(float));
+   m->m[0] = 1.0;
+   m->m[5] = 1.0;
+   m->m[10] = 1.0;
+   m->m[15] = 1.0;
   #else
-    m[0] = 1.0;  m[1] = 0.0;  m[2] = 0.0;   m[3] = 0.0;
-    m[4] = 0.0;  m[5] = 1.0;  m[6] = 0.0;   m[7] = 0.0;
-    m[8] = 0.0;  m[9] = 0.0;  m[10] = 1.0;  m[11] =0.0;
-    m[12]= 0.0;  m[13]= 0.0;  m[14] = 0.0;  m[15] = 1.0;
+    m->m[0] = 1.0;  m->m[1] = 0.0;  m->m[2] = 0.0;   m->m[3] = 0.0;
+    m->m[4] = 0.0;  m->m[5] = 1.0;  m->m[6] = 0.0;   m->m[7] = 0.0;
+    m->m[8] = 0.0;  m->m[9] = 0.0;  m->m[10] = 1.0;  m->m[11] =0.0;
+    m->m[12]= 0.0;  m->m[13]= 0.0;  m->m[14] = 0.0;  m->m[15] = 1.0;
   #endif // OPTIMIZED
 }
-
-
-void create4x4FIdentityMatrix(float * m)
-{
-  #if OPTIMIZED
-   memset(m,0,16*sizeof(float));
-   m[0] = 1.0;
-   m[5] = 1.0;
-   m[10] = 1.0;
-   m[15] = 1.0;
-  #else
-    m[0] = 1.0;  m[1] = 0.0;  m[2] = 0.0;   m[3] = 0.0;
-    m[4] = 0.0;  m[5] = 1.0;  m[6] = 0.0;   m[7] = 0.0;
-    m[8] = 0.0;  m[9] = 0.0;  m[10] = 1.0;  m[11] =0.0;
-    m[12]= 0.0;  m[13]= 0.0;  m[14] = 0.0;  m[15] = 1.0;
-  #endif // OPTIMIZED
-}
-
-int doublePEq(double * element , double value )
-{
- const double machineFloatPercision= 0.0001;
- if ( *element == value ) { return 1; }
-
- if ( ( value-machineFloatPercision<*element ) && (( *element<value+machineFloatPercision )) ) { return 1; }
- return 0;
-}
-
-int is4x4DIdentityMatrix(double * m)
-{
-   return (
-    (doublePEq(&m[0],1.0)) &&(doublePEq(&m[1],0.0)) &&(doublePEq(&m[2],0.0)) &&(doublePEq(&m[3],0.0)) &&
-    (doublePEq(&m[4],0.0)) &&(doublePEq(&m[5],1.0)) &&(doublePEq(&m[6],0.0)) &&(doublePEq(&m[7],0.0)) &&
-    (doublePEq(&m[8],0.0)) &&(doublePEq(&m[9],0.0)) &&(doublePEq(&m[10],1.0))&&(doublePEq(&m[11],0.0))&&
-    (doublePEq(&m[12],0.0))&&(doublePEq(&m[13],0.0))&&(doublePEq(&m[14],0.0))&&(doublePEq(&m[15],1.0))
-           );
-}
-
-
-int is4x4DZeroMatrix(double  * m)
-{
-   return (
-    (doublePEq(&m[0],0.0)) &&(doublePEq(&m[1],0.0)) &&(doublePEq(&m[2],0.0)) &&(doublePEq(&m[3],0.0)) &&
-    (doublePEq(&m[4],0.0)) &&(doublePEq(&m[5],0.0)) &&(doublePEq(&m[6],0.0)) &&(doublePEq(&m[7],0.0)) &&
-    (doublePEq(&m[8],0.0)) &&(doublePEq(&m[9],0.0)) &&(doublePEq(&m[10],0.0))&&(doublePEq(&m[11],0.0))&&
-    (doublePEq(&m[12],0.0))&&(doublePEq(&m[13],0.0))&&(doublePEq(&m[14],0.0))&&(doublePEq(&m[15],0.0))
-           );
-}
-
+ 
 
 int floatPEq(float * element , float value )
 {
@@ -234,50 +175,49 @@ int floatPEq(float * element , float value )
 }
 
 
-int is4x4FIdentityMatrix(float  * m)
+int is4x4FIdentityMatrix(struct Matrix4x4OfFloats * m)
 {
    return (
-    (floatPEq(&m[0],1.0)) &&(floatPEq(&m[1],0.0)) &&(floatPEq(&m[2],0.0)) &&(floatPEq(&m[3],0.0)) &&
-    (floatPEq(&m[4],0.0)) &&(floatPEq(&m[5],1.0)) &&(floatPEq(&m[6],0.0)) &&(floatPEq(&m[7],0.0)) &&
-    (floatPEq(&m[8],0.0)) &&(floatPEq(&m[9],0.0)) &&(floatPEq(&m[10],1.0))&&(floatPEq(&m[11],0.0))&&
-    (floatPEq(&m[12],0.0))&&(floatPEq(&m[13],0.0))&&(floatPEq(&m[14],0.0))&&(floatPEq(&m[15],1.0))
+    (floatPEq(&m->m[0],1.0)) &&(floatPEq(&m->m[1],0.0)) &&(floatPEq(&m->m[2],0.0)) &&(floatPEq(&m->m[3],0.0)) &&
+    (floatPEq(&m->m[4],0.0)) &&(floatPEq(&m->m[5],1.0)) &&(floatPEq(&m->m[6],0.0)) &&(floatPEq(&m->m[7],0.0)) &&
+    (floatPEq(&m->m[8],0.0)) &&(floatPEq(&m->m[9],0.0)) &&(floatPEq(&m->m[10],1.0))&&(floatPEq(&m->m[11],0.0))&&
+    (floatPEq(&m->m[12],0.0))&&(floatPEq(&m->m[13],0.0))&&(floatPEq(&m->m[14],0.0))&&(floatPEq(&m->m[15],1.0))
            );
 }
 
 
-int is4x4FIdentityMatrixPercisionCompensating(float  * m)
+int is4x4FIdentityMatrixPercisionCompensating(struct Matrix4x4OfFloats  * m)
 {
    return (
-    (floatPEq(&m[0],1.0)) &&(floatPEq(&m[1],0.0)) &&(floatPEq(&m[2],0.0)) &&(floatPEq(&m[3],0.0)) &&
-    (floatPEq(&m[4],0.0)) &&(floatPEq(&m[5],1.0)) &&(floatPEq(&m[6],0.0)) &&(floatPEq(&m[7],0.0)) &&
-    (floatPEq(&m[8],0.0)) &&(floatPEq(&m[9],0.0)) &&(floatPEq(&m[10],1.0))&&(floatPEq(&m[11],0.0))&&
-    (floatPEq(&m[12],0.0))&&(floatPEq(&m[13],0.0))&&(floatPEq(&m[14],0.0))&&(floatPEq(&m[15],1.0))
+    (floatPEq(&m->m[0],1.0)) &&(floatPEq(&m->m[1],0.0)) &&(floatPEq(&m->m[2],0.0)) &&(floatPEq(&m->m[3],0.0)) &&
+    (floatPEq(&m->m[4],0.0)) &&(floatPEq(&m->m[5],1.0)) &&(floatPEq(&m->m[6],0.0)) &&(floatPEq(&m->m[7],0.0)) &&
+    (floatPEq(&m->m[8],0.0)) &&(floatPEq(&m->m[9],0.0)) &&(floatPEq(&m->m[10],1.0))&&(floatPEq(&m->m[11],0.0))&&
+    (floatPEq(&m->m[12],0.0))&&(floatPEq(&m->m[13],0.0))&&(floatPEq(&m->m[14],0.0))&&(floatPEq(&m->m[15],1.0))
            );
 }
 
 
-void convert4x4DMatrixToRPY(double *m ,double *roll,double *pitch,double *yaw)
+void convert4x4FMatrixToRPY(struct Matrix4x4OfFloats * m ,float *roll,float *pitch,float *yaw)
 {
- if (m[0] == 1.0f)
+ if (m->m[0] == 1.0f)
         {
-          *yaw = atan2f( m[2], m[11]);
+          *yaw = atan2f( m->m[2], m->m[11]);
           *pitch = 0;
           *roll = 0;
         }
         else
- if (m[0] == -1.0f)
+ if (m->m[0] == -1.0f)
         {
-          *yaw = atan2f(m[2], m[11]);
+          *yaw = atan2f(m->m[2], m->m[11]);
           *pitch = 0;
           *roll = 0;
         }
         else
         {
-          *yaw = atan2(-m[8],m[0]);
-          *pitch = asin(m[4]);
-          *roll = atan2(-m[6],m[5]);
-        }
-
+          *yaw = atan2(-m->m[8],m->m[0]);
+          *pitch = asin(m->m[4]);
+          *roll = atan2(-m->m[6],m->m[5]);
+        } 
 }
 
 
@@ -287,96 +227,91 @@ float degrees_to_radF(float degrees)
 {
     return (float) degrees * ( (float) M_PI / 180.0 );
 }
+ 
 
-
-double degrees_to_rad(double degrees)
+void create4x4FMatrixFromEulerAnglesXYZAllInOne(struct Matrix4x4OfFloats * m ,float eulX,float eulY,float eulZ)
 {
-    return (double) degrees * ( (double) M_PI / 180.0 );
+    float x = degrees_to_radF(eulX);
+    float y = degrees_to_radF(eulY);
+    float z = degrees_to_radF(eulZ);
+
+    float cr = cos( x );
+    float sr = sin( x );
+    float cp = cos( y );
+    float sp = sin( y );
+    float cy = cos( z );
+    float sy = sin( z );
+
+    m->m[0] = cp*cy ;
+    m->m[1] = cp*sy;
+    m->m[2] = -sp ;
+    m->m[3] = 0; // 4x4
+
+
+    float srsp = sr*sp;
+    float crsp = cr*sp;
+
+    m->m[4] = srsp*cy-cr*sy ;
+    m->m[5] = srsp*sy+cr*cy ;
+    m->m[6] = sr*cp ;
+    m->m[7] = 0; // 4x4
+
+    m->m[8] =  crsp*cy+sr*sy ;
+    m->m[9] =  crsp*sy-sr*cy ;
+    m->m[10]= cr*cp ;
+    m->m[11]= 0; // 4x4
+
+    // 4x4 last row
+    m->m[12]= 0;
+    m->m[13]= 0;
+    m->m[14]= 0;
+    m->m[15]= 1.0;
 }
 
 
-void create4x4DMatrixFromEulerAnglesXYZAllInOne(double * m ,double eulX, double eulY, double eulZ)
-{
-    double x = degrees_to_rad(eulX);
-    double y = degrees_to_rad(eulY);
-    double z = degrees_to_rad(eulZ);
-
-	double cr = cos( x );
-	double sr = sin( x );
-	double cp = cos( y );
-	double sp = sin( y );
-	double cy = cos( z );
-	double sy = sin( z );
-
-	m[0] = cp*cy ;
-	m[1] = cp*sy;
-	m[2] = -sp ;
-	m[3] = 0; // 4x4
-
-
-	double srsp = sr*sp;
-	double crsp = cr*sp;
-
-	m[4] = srsp*cy-cr*sy ;
-	m[5] = srsp*sy+cr*cy ;
-	m[6] = sr*cp ;
-	m[7] = 0; // 4x4
-
-	m[8] =  crsp*cy+sr*sy ;
-	m[9] =  crsp*sy-sr*cy ;
-	m[10]= cr*cp ;
-    m[11]= 0; // 4x4
-
-     // 4x4 last row
-    m[12]= 0;
-    m[13]= 0;
-    m[14]= 0;
-    m[15]= 1.0;
-}
-
-
-void create4x4DMatrixFromEulerAnglesZYX(double * m ,double eulX, double eulY, double eulZ)
+void create4x4FMatrixFromEulerAnglesZYX(struct Matrix4x4OfFloats * m ,float eulX,float eulY,float eulZ)
 {
     //roll = X , pitch = Y , yaw = Z
-    double x = degrees_to_rad(eulX);
-    double y = degrees_to_rad(eulY);
-    double z = degrees_to_rad(eulZ);
+    float x = degrees_to_radF(eulX);
+    float y = degrees_to_radF(eulY);
+    float z = degrees_to_radF(eulZ);
 
 
-	double cr = cos(z);
-	double sr = sin(z);
-	double cp = cos(y);
-	double sp = sin(y);
-	double cy = cos(x);
-	double sy = sin(x);
+    float cr = cos(z);
+    float sr = sin(z);
+    float cp = cos(y);
+    float sp = sin(y);
+    float cy = cos(x);
+    float sy = sin(x);
 
-	double srsp = sr*sp;
-	double crsp = cr*sp;
+    float srsp = sr*sp;
+    float crsp = cr*sp;
 
-	m[0] = cr*cp;
-	m[1] = crsp*sy - sr*cy;
-	m[2] = crsp*cy + sr*sy;
-	m[3] = 0;  // 4x4
+    m->m[0] = cr*cp;
+    m->m[1] = crsp*sy - sr*cy;
+    m->m[2] = crsp*cy + sr*sy;
+    m->m[3] = 0;  // 4x4
 
-	m[4] = sr*cp;
-	m[5] = srsp*sy + cr*cy;
-	m[6] = srsp*cy - cr*sy;
-	m[7] = 0;  // 4x4
+    m->m[4] = sr*cp;
+    m->m[5] = srsp*sy + cr*cy;
+    m->m[6] = srsp*cy - cr*sy;
+    m->m[7] = 0;  // 4x4
 
-	m[8] = -sp;
-	m[9] = cp*sy;
-	m[10] = cp*cy;
-	m[11] = 0;  // 4x4
+    m->m[8] = -sp;
+    m->m[9] = cp*sy;
+    m->m[10] = cp*cy;
+    m->m[11] = 0;  // 4x4
 
      // 4x4 last row
-	m[12] = 0;
-	m[13] = 0;
-	m[14] = 0;
-	m[15] = 1;
+    m->m[12] = 0;
+    m->m[13] = 0;
+    m->m[14] = 0;
+    m->m[15] = 1;
 }
 
 
-void create4x4FRotationX(float * m,float degrees)
+//---------------------------------------------------------
+void create4x4FRotationX(struct Matrix4x4OfFloats * m,float degrees)
 {
     float radians = degrees_to_radF(degrees);
 
@@ -386,29 +321,13 @@ void create4x4FRotationX(float * m,float degrees)
     float sinV = (float) sinf((float)radians);
 
     // Rotate X formula.
-    m[5] =    cosV; // [1,1]
-    m[9] = -1*sinV; // [1,2]
-    m[6] =    sinV; // [2,1]
-    m[10] =   cosV; // [2,2]
-}
-
-void create4x4DRotationX(double * m,double degrees)
-{
-    double radians = degrees_to_rad(degrees);
-
-    create4x4DIdentityMatrix(m);
-
-    double cosV = (double) cosf((float)radians);
-    double sinV = (double) sinf((float)radians);
-
-    // Rotate X formula.
-    m[5] =    cosV; // [1,1]
-    m[9] = -1*sinV; // [1,2]
-    m[6] =    sinV; // [2,1]
-    m[10] =   cosV; // [2,2]
+    m->m[5] =    cosV; // [1,1]
+    m->m[9] = -1*sinV; // [1,2]
+    m->m[6] =    sinV; // [2,1]
+    m->m[10] =   cosV; // [2,2]
 }
 //---------------------------------------------------------
-void create4x4FRotationY(float * m,float degrees)
+void create4x4FRotationY(struct Matrix4x4OfFloats * m,float degrees)
 {
     float radians = degrees_to_radF(degrees);
 
@@ -418,29 +337,13 @@ void create4x4FRotationY(float * m,float degrees)
     float sinV = (float) sinf((float)radians);
 
     // Rotate Y formula.
-    m[0] =    cosV; // [0,0]
-    m[2] = -1*sinV; // [2,0]
-    m[8] =    sinV; // [0,2]
-    m[10] =   cosV; // [2,2]
-}
-
-void create4x4DRotationY(double * m,double degrees)
-{
-    double radians = degrees_to_rad(degrees);
-
-    create4x4DIdentityMatrix(m);
-
-    double cosV = (double) cosf((float)radians);
-    double sinV = (double) sinf((float)radians);
-
-    // Rotate Y formula.
-    m[0] =    cosV; // [0,0]
-    m[2] = -1*sinV; // [2,0]
-    m[8] =    sinV; // [0,2]
-    m[10] =   cosV; // [2,2]
+    m->m[0] =    cosV; // [0,0]
+    m->m[2] = -1*sinV; // [2,0]
+    m->m[8] =    sinV; // [0,2]
+    m->m[10] =   cosV; // [2,2]
 }
 //---------------------------------------------------------
-void create4x4FRotationZ(float * m,float degrees)
+void create4x4FRotationZ(struct Matrix4x4OfFloats * m,float degrees)
 {
     float radians = degrees_to_radF(degrees);
 
@@ -450,27 +353,13 @@ void create4x4FRotationZ(float * m,float degrees)
     float sinV = (float) sinf((float)radians);
 
     // Rotate Z formula.
-    m[0] =    cosV;  // [0,0]
-    m[1] =    sinV;  // [1,0]
-    m[4] = -1*sinV;  // [0,1]
-    m[5] =    cosV;  // [1,1]
+    m->m[0] =    cosV;  // [0,0]
+    m->m[1] =    sinV;  // [1,0]
+    m->m[4] = -1*sinV;  // [0,1]
+    m->m[5] =    cosV;  // [1,1]
 }
-
-void create4x4DRotationZ(double * m,double degrees)
-{
-    double radians = degrees_to_rad(degrees);
-
-    create4x4DIdentityMatrix(m);
-
-    double cosV = (double) cosf((float)radians);
-    double sinV = (double) sinf((float)radians);
-
-    // Rotate Z formula.
-    m[0] =    cosV;  // [0,0]
-    m[1] =    sinV;  // [1,0]
-    m[4] = -1*sinV;  // [0,1]
-    m[5] =    cosV;  // [1,1]
-}
+//---------------------------------------------------------
+ 
 
 
 
@@ -495,9 +384,9 @@ void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats *
 
   //Assuming the rotation axis are correct
   //rX,rY,rZ should hold our rotation matrices
-   create4x4FRotationX(rX.m,degreesX);
-   create4x4FRotationY(rY.m,degreesY);
-   create4x4FRotationZ(rZ.m,degreesZ);
+   create4x4FRotationX(&rX,degreesX);
+   create4x4FRotationY(&rY,degreesY);
+   create4x4FRotationZ(&rZ,degreesZ);
 
   switch (rotationOrder)
   {
@@ -542,114 +431,8 @@ void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats *
 
 
 
-
-
-
-
-
-
-void create4x4DMatrixFromEulerAnglesWithRotationOrder(double * m ,double eulX, double eulY, double eulZ,unsigned int rotationOrder)
-{
-   //Initialize rotation matrix..
-   create4x4DIdentityMatrix(m);
-
-  if (rotationOrder==0)
-  {
-    //No rotation type, get's you back an Identity Matrix..
-    fprintf(stderr,"create4x4MatrixFromEulerAnglesWithRotationOrder: No rotation order given, returning identity..\n");
-    return;
-  }
-    double degreesX = eulX;
-    double degreesY = eulY;
-    double degreesZ = eulZ;
-    double rX[16]={0};
-    double rY[16]={0};
-    double rZ[16]={0};
-
-  //Assuming the rotation axis are correct
-  //rX,rY,rZ should hold our rotation matrices
-   create4x4DRotationX(rX,degreesX);
-   create4x4DRotationY(rY,degreesY);
-   create4x4DRotationZ(rZ,degreesZ);
-
-  switch (rotationOrder)
-  {
-    case ROTATION_ORDER_XYZ :
-      multiplyTwo4x4DMatricesBuffered(m,m,rX);
-      multiplyTwo4x4DMatricesBuffered(m,m,rY);
-      multiplyTwo4x4DMatricesBuffered(m,m,rZ);
-    break;
-    case ROTATION_ORDER_XZY :
-      multiplyTwo4x4DMatricesBuffered(m,m,rX);
-      multiplyTwo4x4DMatricesBuffered(m,m,rZ);
-      multiplyTwo4x4DMatricesBuffered(m,m,rY);
-    break;
-    case ROTATION_ORDER_YXZ :
-      multiplyTwo4x4DMatricesBuffered(m,m,rY);
-      multiplyTwo4x4DMatricesBuffered(m,m,rX);
-      multiplyTwo4x4DMatricesBuffered(m,m,rZ);
-    break;
-    case ROTATION_ORDER_YZX :
-      multiplyTwo4x4DMatricesBuffered(m,m,rY);
-      multiplyTwo4x4DMatricesBuffered(m,m,rZ);
-      multiplyTwo4x4DMatricesBuffered(m,m,rX);
-    break;
-    case ROTATION_ORDER_ZXY :
-      multiplyTwo4x4DMatricesBuffered(m,m,rZ);
-      multiplyTwo4x4DMatricesBuffered(m,m,rX);
-      multiplyTwo4x4DMatricesBuffered(m,m,rY);
-    break;
-    case ROTATION_ORDER_ZYX :
-      multiplyTwo4x4DMatricesBuffered(m,m,rZ);
-      multiplyTwo4x4DMatricesBuffered(m,m,rY);
-      multiplyTwo4x4DMatricesBuffered(m,m,rX);
-    break;
-    case ROTATION_ORDER_RPY:
-      fprintf(stderr,"create4x4MatrixFromEulerAnglesWithRotationOrder can't handle RPY\n");
-    break;
-    default :
-      fprintf(stderr,"create4x4MatrixFromEulerAnglesWithRotationOrder: Error, Incorrect rotation type %u\n",rotationOrder);
-    break;
-  };
-}
-
-
-void create4x4DRotationMatrix(double * m , double angle, double x, double y, double z)
-{
-    double const DEG2RAD=(double) M_PI/180;
-    double c = cosf(angle * DEG2RAD);
-    double s = sinf(angle * DEG2RAD);
-    double xx = x * x;
-    double xy = x * y;
-    double xz = x * z;
-    double yy = y * y;
-    double yz = y * z;
-    double zz = z * z;
-    double one_min_c = (1 - c);
-    double x_mul_s = x * s;
-    double y_mul_s = y * s;
-    double z_mul_s = z * s;
-
-    m[0] = xx * one_min_c + c;
-    m[1] = xy * one_min_c - z_mul_s;
-    m[2] = xz * one_min_c + y_mul_s;
-    m[3] = 0;
-    m[4] = xy * one_min_c + z_mul_s;
-    m[5] = yy * one_min_c + c;
-    m[6] = yz * one_min_c - x_mul_s;
-    m[7] = 0;
-    m[8] = xz * one_min_c - y_mul_s;
-    m[9] = yz * one_min_c + x_mul_s;
-    m[10]= zz * one_min_c + c;
-    m[11]= 0;
-    m[12]= 0;
-    m[13]= 0;
-    m[14]= 0;
-    m[15]= 1;
-}
-
-
-void create4x4FRotationMatrix(float * m , float angle, float x, float y, float z)
+ 
+void create4x4FRotationMatrix(struct Matrix4x4OfFloats * m , float angle, float x, float y, float z)
 {
     float const DEG2RAD=(float) M_PI/180;
     float c = cosf(angle * DEG2RAD);
@@ -665,101 +448,87 @@ void create4x4FRotationMatrix(float * m , float angle, float x, float y, float z
     float y_mul_s = y * s;
     float z_mul_s = z * s;
 
-    m[0] = xx * one_min_c + c;
-    m[1] = xy * one_min_c - z_mul_s;
-    m[2] = xz * one_min_c + y_mul_s;
-    m[3] = 0;
-    m[4] = xy * one_min_c + z_mul_s;
-    m[5] = yy * one_min_c + c;
-    m[6] = yz * one_min_c - x_mul_s;
-    m[7] = 0;
-    m[8] = xz * one_min_c - y_mul_s;
-    m[9] = yz * one_min_c + x_mul_s;
-    m[10]= zz * one_min_c + c;
-    m[11]= 0;
-    m[12]= 0;
-    m[13]= 0;
-    m[14]= 0;
-    m[15]= 1;
+    m->m[0] = xx * one_min_c + c;
+    m->m[1] = xy * one_min_c - z_mul_s;
+    m->m[2] = xz * one_min_c + y_mul_s;
+    m->m[3] = 0;
+    m->m[4] = xy * one_min_c + z_mul_s;
+    m->m[5] = yy * one_min_c + c;
+    m->m[6] = yz * one_min_c - x_mul_s;
+    m->m[7] = 0;
+    m->m[8] = xz * one_min_c - y_mul_s;
+    m->m[9] = yz * one_min_c + x_mul_s;
+    m->m[10]= zz * one_min_c + c;
+    m->m[11]= 0;
+    m->m[12]= 0;
+    m->m[13]= 0;
+    m->m[14]= 0;
+    m->m[15]= 1;
 }
 
-void create4x4DQuaternionMatrix(double * m , double qX,double qY,double qZ,double qW)
+void create4x4FQuaternionMatrix(struct Matrix4x4OfFloats * m,float qX,float qY,float qZ,float qW)
 {
-    double yy2 = 2.0f * qY * qY;
-    double xy2 = 2.0f * qX * qY;
-    double xz2 = 2.0f * qX * qZ;
-    double yz2 = 2.0f * qY * qZ;
-    double zz2 = 2.0f * qZ * qZ;
-    double wz2 = 2.0f * qW * qZ;
-    double wy2 = 2.0f * qW * qY;
-    double wx2 = 2.0f * qW * qX;
-    double xx2 = 2.0f * qX * qX;
-    m[0]  = - yy2 - zz2 + 1.0f;
-    m[1]  = xy2 + wz2;
-    m[2]  = xz2 - wy2;
-    m[3]  = 0;
-    m[4]  = xy2 - wz2;
-    m[5]  = - xx2 - zz2 + 1.0f;
-    m[6]  = yz2 + wx2;
-    m[7]  = 0;
-    m[8]  = xz2 + wy2;
-    m[9]  = yz2 - wx2;
-    m[10] = - xx2 - yy2 + 1.0f;
-    m[11] = 0.0f;
-    m[12] = 0.0;
-    m[13] = 0.0;
-    m[14] = 0.0;
-    m[15] = 1.0f;
+    float yy2 = 2.0f * qY * qY;
+    float xy2 = 2.0f * qX * qY;
+    float xz2 = 2.0f * qX * qZ;
+    float yz2 = 2.0f * qY * qZ;
+    float zz2 = 2.0f * qZ * qZ;
+    float wz2 = 2.0f * qW * qZ;
+    float wy2 = 2.0f * qW * qY;
+    float wx2 = 2.0f * qW * qX;
+    float xx2 = 2.0f * qX * qX;
+    m->m[0]  = - yy2 - zz2 + 1.0f;
+    m->m[1]  = xy2 + wz2;
+    m->m[2]  = xz2 - wy2;
+    m->m[3]  = 0;
+    m->m[4]  = xy2 - wz2;
+    m->m[5]  = - xx2 - zz2 + 1.0f;
+    m->m[6]  = yz2 + wx2;
+    m->m[7]  = 0;
+    m->m[8]  = xz2 + wy2;
+    m->m[9]  = yz2 - wx2;
+    m->m[10] = - xx2 - yy2 + 1.0f;
+    m->m[11] = 0.0f;
+    m->m[12] = 0.0;
+    m->m[13] = 0.0;
+    m->m[14] = 0.0;
+    m->m[15] = 1.0f;
 }
 
 
-void create4x4FTranslationMatrix(float * m , float x, float y, float z)
+void create4x4FTranslationMatrix(struct Matrix4x4OfFloats * m , float x, float y, float z)
 {
   #if OPTIMIZED
-   memset(m,0,16*sizeof(float));
-   m[0] = 1.0;
-   m[3] = x;
-   m[5] = 1.0;
-   m[7] = y;
-   m[10] = 1.0;
-   m[11] = z;
-   m[15] = 1.0;
+   memset(m->m,0,16*sizeof(float));
+   m->m[0] = 1.0;
+   m->m[3] = x;
+   m->m[5] = 1.0;
+   m->m[7] = y;
+   m->m[10] = 1.0;
+   m->m[11] = z;
+   m->m[15] = 1.0;
   #else
     create4x4FIdentityMatrix(m);
     // Translate slots.
-    m[3] = x; m[7] = y; m[11] = z;
+    m->m[3] = x; m->m[7] = y; m->m[11] = z;
   #endif // OPTIMIZED
 }
 
+ 
 
-
-void create4x4DTranslationMatrix(double * matrix , double x, double y, double z)
+void create4x4FScalingMatrix(struct Matrix4x4OfFloats * m , float scaleX, float scaleY, float scaleZ)
 {
-    create4x4DIdentityMatrix(matrix);
-    // Translate slots.
-    matrix[3] = x; matrix[7] = y; matrix[11] = z;
-}
-
-
-void create4x4FScalingMatrix(float * matrix , float scaleX, float scaleY, float scaleZ)
-{
-    create4x4FIdentityMatrix(matrix);
+    if (m==0) { return ;} 
+    create4x4FIdentityMatrix(m);
     // Scale slots.
-    matrix[0] = scaleX; matrix[5] = scaleY; matrix[10] = scaleZ;
+    m->m[0] = scaleX; m->m[5] = scaleY; m->m[10] = scaleZ;
 }
-
-void create4x4DScalingMatrix(double * matrix , double scaleX, double scaleY, double scaleZ)
+ 
+float det4x4FMatrix(float * mat)
 {
-    create4x4DIdentityMatrix(matrix);
-    // Scale slots.
-    matrix[0] = scaleX; matrix[5] = scaleY; matrix[10] = scaleZ;
-}
+ float * a = mat;
 
-double det4x4DMatrix(double * mat)
-{
- double * a = mat;
-
- double  detA  = a[I11] * a[I22] * a[I33]  * a[I44];
+ float   detA  = a[I11] * a[I22] * a[I33]  * a[I44];
          detA += a[I11] * a[I23] * a[I34]  * a[I42];
          detA += a[I11] * a[I24] * a[I32]  * a[I43];
 
@@ -796,18 +565,18 @@ double det4x4DMatrix(double * mat)
 }
 
 
-int invert4x4DMatrix(double * result,double * mat)
+int invert4x4FMatrix(float * result,float * mat)
 {
- double * a = mat;
- double * b = result;
- double detA = det4x4DMatrix(mat);
+ float * a = mat;
+ float * b = result;
+ float detA = det4x4FMatrix(mat);
  if (detA==0.0)
     {
-      copy4x4DMatrix(result,mat);
+      copy4x4FMatrix(result,mat);
       fprintf(stderr,"Matrix 4x4 cannot be inverted (det = 0)\n");
       return 0;
     }
- double one_div_detA = (double) 1 / detA;
+ float one_div_detA = (float) 1 / detA;
 
  //FIRST LINE
  b[I11]  = a[I22] * a[I33] * a[I44] +  a[I23] * a[I34] * a[I42]  + a[I24] * a[I32] * a[I43];
@@ -879,8 +648,8 @@ int invert4x4DMatrix(double * result,double * mat)
 
 
  #if PRINT_MATRIX_DEBUGGING
-  print4x4DMatrix("Inverted Matrix From Source",a);
-  print4x4DMatrix("Inverted Matrix To Target",b);
+  print4x4FMatrix("Inverted Matrix From Source",a);
+  print4x4FMatrix("Inverted Matrix To Target",b);
  #endif // PRINT_MATRIX_DEBUGGING
 
  return 1;
@@ -909,107 +678,9 @@ int transpose4x4FMatrix(float * mat)
   return 1;
 }
 
+ 
 
-int transpose4x4DMatrix(double * mat)
-{
-  if (mat==0) { return 0; }
-  /*       -------  TRANSPOSE ------->
-      0   1   2   3           0  4  8   12
-      4   5   6   7           1  5  9   13
-      8   9   10  11          2  6  10  14
-      12  13  14  15          3  7  11  15   */
-
-  double tmp;
-  tmp = mat[1]; mat[1]=mat[4];  mat[4]=tmp;
-  tmp = mat[2]; mat[2]=mat[8];  mat[8]=tmp;
-  tmp = mat[3]; mat[3]=mat[12]; mat[12]=tmp;
-
-
-  tmp = mat[6]; mat[6]=mat[9]; mat[9]=tmp;
-  tmp = mat[13]; mat[13]=mat[7]; mat[7]=tmp;
-  tmp = mat[14]; mat[14]=mat[11]; mat[11]=tmp;
-
-  return 1;
-}
-
-
-//matrixA x matrixB
-int multiplyTwo4x4DMatrices(double * result , double * matrixA , double * matrixB)
-{
-  if ( (matrixA==0) || (matrixB==0) || (result==0) ) { return 0; }
-
-  #if PRINT_MATRIX_DEBUGGING
-  fprintf(stderr,"Multiplying 4x4 A and B \n");
-  print4x4DMatrix("A", matrixA);
-  print4x4DMatrix("B", matrixB);
-  #endif // PRINT_MATRIX_DEBUGGING
-
-
-  //MULTIPLICATION_RESULT FIRST ROW
-  result[0]=matrixA[0] * matrixB[0] + matrixA[1] * matrixB[4]  + matrixA[2] * matrixB[8]  + matrixA[3] * matrixB[12];
-  result[1]=matrixA[0] * matrixB[1] + matrixA[1] * matrixB[5]  + matrixA[2] * matrixB[9]  + matrixA[3] * matrixB[13];
-  result[2]=matrixA[0] * matrixB[2] + matrixA[1] * matrixB[6]  + matrixA[2] * matrixB[10] + matrixA[3] * matrixB[14];
-  result[3]=matrixA[0] * matrixB[3] + matrixA[1] * matrixB[7]  + matrixA[2] * matrixB[11] + matrixA[3] * matrixB[15];
-
-  //MULTIPLICATION_RESULT SECOND ROW
-  result[4]=matrixA[4] * matrixB[0] + matrixA[5] * matrixB[4]  + matrixA[6] * matrixB[8]  + matrixA[7] * matrixB[12];
-  result[5]=matrixA[4] * matrixB[1] + matrixA[5] * matrixB[5]  + matrixA[6] * matrixB[9]  + matrixA[7] * matrixB[13];
-  result[6]=matrixA[4] * matrixB[2] + matrixA[5] * matrixB[6]  + matrixA[6] * matrixB[10] + matrixA[7] * matrixB[14];
-  result[7]=matrixA[4] * matrixB[3] + matrixA[5] * matrixB[7]  + matrixA[6] * matrixB[11] + matrixA[7] * matrixB[15];
-
-  //MULTIPLICATION_RESULT FOURTH ROW
-  result[8] =matrixA[8] * matrixB[0] + matrixA[9] * matrixB[4]  + matrixA[10] * matrixB[8]   + matrixA[11] * matrixB[12];
-  result[9] =matrixA[8] * matrixB[1] + matrixA[9] * matrixB[5]  + matrixA[10] * matrixB[9]   + matrixA[11] * matrixB[13];
-  result[10]=matrixA[8] * matrixB[2] + matrixA[9] * matrixB[6]  + matrixA[10] * matrixB[10]  + matrixA[11] * matrixB[14];
-  result[11]=matrixA[8] * matrixB[3] + matrixA[9] * matrixB[7]  + matrixA[10] * matrixB[11]  + matrixA[11] * matrixB[15];
-
-  result[12]=matrixA[12] * matrixB[0] + matrixA[13] * matrixB[4]  + matrixA[14] * matrixB[8]    + matrixA[15] * matrixB[12];
-  result[13]=matrixA[12] * matrixB[1] + matrixA[13] * matrixB[5]  + matrixA[14] * matrixB[9]    + matrixA[15] * matrixB[13];
-  result[14]=matrixA[12] * matrixB[2] + matrixA[13] * matrixB[6]  + matrixA[14] * matrixB[10]   + matrixA[15] * matrixB[14];
-  result[15]=matrixA[12] * matrixB[3] + matrixA[13] * matrixB[7]  + matrixA[14] * matrixB[11]   + matrixA[15] * matrixB[15];
-
-  #if PRINT_MATRIX_DEBUGGING
-   print4x4DMatrix("AxB", result);
-  #endif // PRINT_MATRIX_DEBUGGING
-
-  return 1;
-}
-
-int multiplyTwo4x4DMatricesBuffered(double * result , double * matrixA , double * matrixB)
-{
-  double bufA[16];
-   copy4x4DMatrix(bufA,matrixA);
-  double bufB[16];
-   copy4x4DMatrix(bufB,matrixB);
-  return  multiplyTwo4x4DMatrices(result,bufA,bufB);
-}
-
-
-int multiplyThree4x4DMatrices(double * result , double * matrixA , double * matrixB , double * matrixC)
-{
-  if ( (matrixA==0) || (matrixB==0) || (matrixC==0) || (result==0) ) { return 0; }
-
-  int i=0;
-  double tmp[16];
-  i+=multiplyTwo4x4DMatrices(tmp,matrixB,matrixC);
-  i+=multiplyTwo4x4DMatrices(result , matrixA , tmp);
-
-  return (i==2);
-}
-
-int multiplyFour4x4DMatrices(double * result , double * matrixA , double * matrixB , double * matrixC , double * matrixD)
-{
-  if ( (matrixA==0) || (matrixB==0) || (matrixC==0) || (matrixD==0) || (result==0) ) { return 0; }
-
-  int i=0;
-  double tmpA[16];
-  double tmpB[16];
-  i+=multiplyTwo4x4DMatrices(tmpA,matrixC,matrixD);
-  i+=multiplyTwo4x4DMatrices(tmpB , matrixB , tmpA);
-  i+=multiplyTwo4x4DMatrices(result , matrixA , tmpB);
-
-  return (i==3);
-}
+ 
 
 
 int multiplyTwo4x4FMatrices_Naive(float * result , float * matrixA , float * matrixB)
@@ -1121,7 +792,7 @@ int multiplyTwo4x4FMatricesBuffered(float * result , float * matrixA , float * m
    copy4x4FMatrix(bufA,matrixA);
   float bufB[16];
    copy4x4FMatrix(bufB,matrixB);
-  return  multiplyTwo4x4FMatrices(result,bufA,bufB);
+  return  multiplyTwo4x4FMatricesS(result,bufA,bufB);
 }
 
 
@@ -1138,7 +809,22 @@ int multiplyThree4x4FMatrices(struct Matrix4x4OfFloats * result,struct Matrix4x4
 }
 
 
-int transform3DNormalVectorUsing3x3DPartOf4x4DMatrix(double * resultPoint3D, double * transformation4x4, double * point3D)
+int multiplyFour4x4FMatrices(struct Matrix4x4OfFloats * result ,struct Matrix4x4OfFloats * matrixA ,struct Matrix4x4OfFloats * matrixB ,struct Matrix4x4OfFloats * matrixC ,struct Matrix4x4OfFloats * matrixD)
+{
+  if ( (matrixA==0) || (matrixB==0) || (matrixC==0) || (matrixD==0) || (result==0) ) { return 0; }
+
+  int i=0;
+  struct Matrix4x4OfFloats tmpA;
+  struct Matrix4x4OfFloats tmpB;
+  i+=multiplyTwo4x4FMatricesS(&tmpA,matrixC,matrixD);
+  i+=multiplyTwo4x4FMatricesS(&tmpB,matrixB,&tmpA);
+  i+=multiplyTwo4x4FMatricesS(result,matrixA,&tmpB);
+
+  return (i==3);
+}
+
+
+int transform3FNormalVectorUsing3x3FPartOf4x4FMatrix(float * resultPoint3D,struct Matrix4x4OfFloats * transformation4x4,float * point3D)
 {
   if ( (resultPoint3D==0) || (transformation4x4==0) || (point3D==0))  { return 0; }
 
@@ -1149,8 +835,8 @@ int transform3DNormalVectorUsing3x3DPartOf4x4DMatrix(double * resultPoint3D, dou
     return 0;
   }
 
-  double * m = transformation4x4;
-  register double X=point3D[0],Y=point3D[1],W=point3D[2];
+  float * m = transformation4x4->m;
+  register float X=point3D[0],Y=point3D[1],W=point3D[2];
   /*
   What we want to do ( in mathematica )
    { {me0,me1,me2} , {me3,me4,me5} , {me6,me7,me8} } * { { X } , { Y } , { W } }
@@ -1164,9 +850,9 @@ int transform3DNormalVectorUsing3x3DPartOf4x4DMatrix(double * resultPoint3D, dou
   }
 */
 
-  double * me0=&m[e0] , * me1=&m[e1] , * me2=&m[e2]  ;  //m[e3]  ignored
-  double * me3=&m[e4] , * me4=&m[e5] , * me5=&m[e6]  ;  //m[e7]  ignored
-  double * me6=&m[e8] , * me7=&m[e9] , * me8=&m[e10] ;  //m[e11] ignored
+  float * me0=&m[e0] , * me1=&m[e1] , * me2=&m[e2]  ;  //m[e3]  ignored
+  float * me3=&m[e4] , * me4=&m[e5] , * me5=&m[e6]  ;  //m[e7]  ignored
+  float * me6=&m[e8] , * me7=&m[e9] , * me8=&m[e10] ;  //m[e11] ignored
   //       last line ignored since we only want 3x3
 
 
@@ -1188,53 +874,7 @@ int transform3DNormalVectorUsing3x3DPartOf4x4DMatrix(double * resultPoint3D, dou
 
 
 
-
-int transform3DPointDVectorUsing4x4DMatrix(double * resultPoint3D, double * transformation4x4, double * point3D)
-{
-  if ( (resultPoint3D==0) || (transformation4x4==0) || (point3D==0))  { return 0; }
-
-/*
-   What we want to do ( in mathematica )
-   { {e0,e1,e2,e3} , {e4,e5,e6,e7} , {e8,e9,e10,e11} , {e12,e13,e14,e15} } * { { X } , { Y }  , { Z } , { W } }
-
-   This gives us
-
-  {
-    {e3 W + e0 X + e1 Y + e2 Z},
-    {e7 W + e4 X + e5 Y + e6 Z},
-    {e11 W + e8 X + e9 Y + e10 Z},
-    {e15 W + e12 X + e13 Y + e14 Z}
-  }
-*/
-  double * m = transformation4x4;
-  register double X=point3D[0],Y=point3D[1],Z=point3D[2],W=point3D[3];
-
-  resultPoint3D[0] =  m[e3] * W + m[e0] * X + m[e1] * Y + m[e2] * Z;
-  resultPoint3D[1] =  m[e7] * W + m[e4] * X + m[e5] * Y + m[e6] * Z;
-  resultPoint3D[2] =  m[e11] * W + m[e8] * X + m[e9] * Y + m[e10] * Z;
-  resultPoint3D[3] =  m[e15] * W + m[e12] * X + m[e13] * Y + m[e14] * Z;
-
-  // Ok we have our results but now to normalize our vector
-  if (resultPoint3D[3]!=0.0)
-  {
-   resultPoint3D[0]/=resultPoint3D[3];
-   resultPoint3D[1]/=resultPoint3D[3];
-   resultPoint3D[2]/=resultPoint3D[3];
-   resultPoint3D[3]=1.0; // resultPoint3D[3]/=resultPoint3D[3];
-   return 1;
-  } else
-  {
-     fprintf(stderr,"Error with W coordinate after multiplication of 3D Point with 4x4 Matrix\n");
-     print4x4DMatrix("Matrix was",transformation4x4,1);
-     fprintf(stderr,"Input Point was %0.2f %0.2f %0.2f %0.2f \n",point3D[0],point3D[1],point3D[2],point3D[3]);
-     fprintf(stderr,"Output Point was %0.2f %0.2f %0.2f %0.2f \n",resultPoint3D[0],resultPoint3D[1],resultPoint3D[2],resultPoint3D[3]);
-     return 0;
-  }
-
- return 1;
-}
-
-
+ 
 
 
 int transform3DPointFVectorUsing4x4FMatrix(float * resultPoint3D, float * transformation4x4, float * point3D)
@@ -1493,42 +1133,42 @@ void create4x4DModelTransformation(
 }*/
 
 
-void create4x4DCameraModelViewMatrixForRendering(
-                                                double * m ,
+void create4x4FCameraModelViewMatrixForRendering(
+                                                struct Matrix4x4OfFloats * m ,
                                                 //Rotation Component
-                                                double rotationX_angleDegrees,
-                                                double rotationY_angleDegrees,
-                                                double rotationZ_angleDegrees ,
+                                                float rotationX_angleDegrees,
+                                                float rotationY_angleDegrees,
+                                                float rotationZ_angleDegrees ,
                                                 //Translation Component
-                                                double translationX_angleDegrees,
-                                                double translationY_angleDegrees,
-                                                double translationZ_angleDegrees
+                                                float translationX_angleDegrees,
+                                                float translationY_angleDegrees,
+                                                float translationZ_angleDegrees
                                                )
 {
     if (m==0) {return;}
 
-    double intermediateMatrixRX[16];
-    double intermediateMatrixRY[16];
-    double intermediateMatrixRZ[16];
-    create4x4DRotationMatrix(  intermediateMatrixRX, rotationX_angleDegrees,  -1.0,   0.0,   0.0);
-    create4x4DRotationMatrix(  intermediateMatrixRY, rotationY_angleDegrees,   0.0,  -1.0,   0.0);
-    create4x4DRotationMatrix(  intermediateMatrixRZ, rotationZ_angleDegrees,   0.0,   0.0,  -1.0);
+    struct Matrix4x4OfFloats intermediateMatrixRX;
+    struct Matrix4x4OfFloats intermediateMatrixRY;
+    struct Matrix4x4OfFloats intermediateMatrixRZ;
+    create4x4FRotationMatrix(&intermediateMatrixRX, rotationX_angleDegrees,  -1.0,   0.0,   0.0);
+    create4x4FRotationMatrix(&intermediateMatrixRY, rotationY_angleDegrees,   0.0,  -1.0,   0.0);
+    create4x4FRotationMatrix(&intermediateMatrixRZ, rotationZ_angleDegrees,   0.0,   0.0,  -1.0);
 
-    double intermediateMatrixRotation[16];
-    multiplyThree4x4DMatrices(
-                              intermediateMatrixRotation ,
-                              intermediateMatrixRX ,
-                              intermediateMatrixRY ,
-                              intermediateMatrixRZ
+    struct Matrix4x4OfFloats intermediateMatrixRotation;
+    multiplyThree4x4FMatrices(
+                              &intermediateMatrixRotation ,
+                              &intermediateMatrixRX ,
+                              &intermediateMatrixRY ,
+                              &intermediateMatrixRZ
                              );
 
-    double intermediateMatrixTranslation[16];
-    create4x4DTranslationMatrix(
-                               intermediateMatrixTranslation,
+    struct Matrix4x4OfFloats intermediateMatrixTranslation;
+    create4x4FTranslationMatrix(
+                               &intermediateMatrixTranslation,
                                -translationX_angleDegrees,
                                -translationY_angleDegrees,
                                -translationZ_angleDegrees
                               );
 
-    multiplyTwo4x4DMatrices(m,intermediateMatrixRotation,intermediateMatrixTranslation);
+    multiplyTwo4x4FMatricesS(m,&intermediateMatrixRotation,&intermediateMatrixTranslation);
 }

--- a/tools/AmMatrix/matrix4x4Tools.c
+++ b/tools/AmMatrix/matrix4x4Tools.c
@@ -388,37 +388,63 @@ void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats *
    create4x4FRotationY(&rY,degreesY);
    create4x4FRotationZ(&rZ,degreesZ);
 
+   #define SPEEDUP_ROTATION_CALCULATIONS 1
+
   switch (rotationOrder)
   {
     case ROTATION_ORDER_XYZ :
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+      #if SPEEDUP_ROTATION_CALCULATIONS 
+       multiplyThree4x4FMatrices(m,&rX,&rY,&rZ);
+      #else 
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+      #endif
     break;
     case ROTATION_ORDER_XZY :
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+      #if SPEEDUP_ROTATION_CALCULATIONS 
+       multiplyThree4x4FMatrices(m,&rX,&rZ,&rY);
+      #else 
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+      #endif
     break;
     case ROTATION_ORDER_YXZ :
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+      #if SPEEDUP_ROTATION_CALCULATIONS 
+       multiplyThree4x4FMatrices(m,&rY,&rX,&rZ);
+      #else 
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+      #endif
     break;
     case ROTATION_ORDER_YZX :
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+      #if SPEEDUP_ROTATION_CALCULATIONS 
+       multiplyThree4x4FMatrices(m,&rY,&rZ,&rX);
+      #else 
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+      #endif
     break;
     case ROTATION_ORDER_ZXY :
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+      #if SPEEDUP_ROTATION_CALCULATIONS 
+       multiplyThree4x4FMatrices(m,&rZ,&rX,&rY);
+      #else 
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+      #endif
     break;
     case ROTATION_ORDER_ZYX :
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
-      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+      #if SPEEDUP_ROTATION_CALCULATIONS 
+       multiplyThree4x4FMatrices(m,&rZ,&rY,&rX);
+      #else 
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+       multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+      #endif
     break;
     case ROTATION_ORDER_RPY:
       fprintf(stderr,"create4x4MatrixFromEulerAnglesWithRotationOrderF can't handle RPY\n");

--- a/tools/AmMatrix/matrix4x4Tools.c
+++ b/tools/AmMatrix/matrix4x4Tools.c
@@ -824,14 +824,14 @@ int multiplyFour4x4FMatrices(struct Matrix4x4OfFloats * result ,struct Matrix4x4
 }
 
 
-int transform3FNormalVectorUsing3x3FPartOf4x4FMatrix(float * resultPoint3D,struct Matrix4x4OfFloats * transformation4x4,float * point3D)
+int transform3DNormalVectorUsing3x3FPartOf4x4FMatrix(float * resultPoint3D,struct Matrix4x4OfFloats * transformation4x4,float * point3D)
 {
   if ( (resultPoint3D==0) || (transformation4x4==0) || (point3D==0))  { return 0; }
 
 
   if (point3D[3]!=0.0)
   {
-    fprintf(stderr,"Error with W coordinate transform3DNormalVectorUsing3x3PartOf4x4Matrix , should be zero  \n");
+    fprintf(stderr,"Error with W coordinate transform3DNormalVectorUsing3x3FPartOf4x4FMatrix , should be zero  \n");
     return 0;
   }
 

--- a/tools/AmMatrix/matrix4x4Tools.c
+++ b/tools/AmMatrix/matrix4x4Tools.c
@@ -163,6 +163,9 @@ void create4x4FIdentityMatrix(struct Matrix4x4OfFloats * m)
     m->m[12]= 0.0;  m->m[13]= 0.0;  m->m[14] = 0.0;  m->m[15] = 1.0;
   #endif // OPTIMIZED
 }
+
+ 
+ 
  
 
 int floatPEq(float * element , float value )
@@ -175,14 +178,20 @@ int floatPEq(float * element , float value )
 }
 
 
-int is4x4FIdentityMatrix(struct Matrix4x4OfFloats * m)
+int is4x4FIdentityMatrix(float  * m)
 {
    return (
-    (floatPEq(&m->m[0],1.0)) &&(floatPEq(&m->m[1],0.0)) &&(floatPEq(&m->m[2],0.0)) &&(floatPEq(&m->m[3],0.0)) &&
-    (floatPEq(&m->m[4],0.0)) &&(floatPEq(&m->m[5],1.0)) &&(floatPEq(&m->m[6],0.0)) &&(floatPEq(&m->m[7],0.0)) &&
-    (floatPEq(&m->m[8],0.0)) &&(floatPEq(&m->m[9],0.0)) &&(floatPEq(&m->m[10],1.0))&&(floatPEq(&m->m[11],0.0))&&
-    (floatPEq(&m->m[12],0.0))&&(floatPEq(&m->m[13],0.0))&&(floatPEq(&m->m[14],0.0))&&(floatPEq(&m->m[15],1.0))
-           );
+           (floatPEq(&m[0],1.0)) &&(floatPEq(&m[1],0.0)) &&(floatPEq(&m[2],0.0)) &&(floatPEq(&m[3],0.0)) &&
+           (floatPEq(&m[4],0.0)) &&(floatPEq(&m[5],1.0)) &&(floatPEq(&m[6],0.0)) &&(floatPEq(&m[7],0.0)) &&
+           (floatPEq(&m[8],0.0)) &&(floatPEq(&m[9],0.0)) &&(floatPEq(&m[10],1.0))&&(floatPEq(&m[11],0.0))&&
+           (floatPEq(&m[12],0.0))&&(floatPEq(&m[13],0.0))&&(floatPEq(&m[14],0.0))&&(floatPEq(&m[15],1.0))
+          );
+}
+
+
+int is4x4FIdentityMatrixS(struct Matrix4x4OfFloats * m)
+{
+   return is4x4FIdentityMatrix(m->m);
 }
 
 
@@ -364,7 +373,7 @@ void create4x4FRotationZ(struct Matrix4x4OfFloats * m,float degrees)
 
 
 
-void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats * m ,float eulX, float eulY, float eulZ,unsigned int rotationOrder)
+void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats * m,float eulX, float eulY, float eulZ,unsigned int rotationOrder)
 {
    //Initialize rotation matrix..
    create4x4FIdentityMatrix(m);
@@ -729,7 +738,7 @@ int transpose4x4DMatrix(double * mat)
 
 
  
-int multiplyTwo4x4DMatrices(double * result ,double * matrixA ,double * matrixB)
+int multiplyTwo4x4DMatrices(double * result ,double * matrixA ,double * matrixB) 
 {
   if ( (matrixA==0) || (matrixB==0) || (result==0) ) { return 0; }
 
@@ -770,6 +779,20 @@ int multiplyTwo4x4DMatrices(double * result ,double * matrixA ,double * matrixB)
 
   return 1;
 }
+
+
+int multiplyThree4x4DMatrices(double * result , double * matrixA , double * matrixB , double * matrixC)
+{
+  if ( (matrixA==0) || (matrixB==0) || (matrixC==0) || (result==0) ) { return 0; }
+
+  int i=0;
+  double tmp[16];
+  i+=multiplyTwo4x4DMatrices(tmp,matrixB,matrixC);
+  i+=multiplyTwo4x4DMatrices(result , matrixA , tmp);
+
+  return (i==2);
+}
+
 
 
 int multiplyTwo4x4FMatrices_Naive(float * result , float * matrixA , float * matrixB)

--- a/tools/AmMatrix/matrix4x4Tools.c
+++ b/tools/AmMatrix/matrix4x4Tools.c
@@ -101,8 +101,8 @@ void copy3x3FMatrixTo4x4F(float * out,float * in)
 {
   out[0]=in[0];   out[1]=in[1];   out[2]=in[2];   out[3]=0.0;
   out[4]=in[3];   out[5]=in[4];   out[6]=in[5];   out[7]=0.0;
-  out[8]=in[6];   out[9]=in[7];   out[10]=in[8]; out[11]=0.0;
-  out[12]=0.0; out[13]=0.0; out[14]=0.0; out[15]=1.0;
+  out[8]=in[6];   out[9]=in[7];   out[10]=in[8];  out[11]=0.0;
+  out[12]=0.0;    out[13]=0.0;    out[14]=0.0;    out[15]=1.0;
 }
 
 void copy4x4FMatrix(float * out,float * in)
@@ -187,6 +187,18 @@ int is4x4FIdentityMatrix(float  * m)
            (floatPEq(&m[12],0.0))&&(floatPEq(&m[13],0.0))&&(floatPEq(&m[14],0.0))&&(floatPEq(&m[15],1.0))
           );
 }
+
+
+int is4x4FZeroMatrix(float  * m)
+{
+   return (
+            (floatPEq(&m[0],0.0)) &&(floatPEq(&m[1],0.0)) &&(floatPEq(&m[2],0.0)) &&(floatPEq(&m[3],0.0)) &&
+            (floatPEq(&m[4],0.0)) &&(floatPEq(&m[5],0.0)) &&(floatPEq(&m[6],0.0)) &&(floatPEq(&m[7],0.0)) &&
+            (floatPEq(&m[8],0.0)) &&(floatPEq(&m[9],0.0)) &&(floatPEq(&m[10],0.0))&&(floatPEq(&m[11],0.0))&&
+            (floatPEq(&m[12],0.0))&&(floatPEq(&m[13],0.0))&&(floatPEq(&m[14],0.0))&&(floatPEq(&m[15],0.0))
+           );
+}
+
 
 
 int is4x4FIdentityMatrixS(struct Matrix4x4OfFloats * m)
@@ -907,6 +919,18 @@ int multiplyTwo4x4FMatricesBuffered(struct Matrix4x4OfFloats * result , float * 
   return  multiplyTwo4x4FMatricesS(result,&bufA,&bufB);
 }
 
+
+int multiplyThree4x4FMatrices_Naive(float * result , float * matrixA , float * matrixB , float * matrixC)
+{
+  if ( (matrixA==0) || (matrixB==0) || (matrixC==0) || (result==0) ) { return 0; }
+
+  int i=0;
+  float tmp[16];
+  i+=multiplyTwo4x4FMatrices(tmp,matrixB,matrixC);
+  i+=multiplyTwo4x4FMatrices(result , matrixA , tmp);
+
+  return (i==2);
+}
 
 int multiplyThree4x4FMatrices(struct Matrix4x4OfFloats * result,struct Matrix4x4OfFloats * matrixA,struct Matrix4x4OfFloats * matrixB ,struct Matrix4x4OfFloats * matrixC)
 {

--- a/tools/AmMatrix/matrix4x4Tools.c
+++ b/tools/AmMatrix/matrix4x4Tools.c
@@ -391,34 +391,34 @@ void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats *
   switch (rotationOrder)
   {
     case ROTATION_ORDER_XYZ :
-      multiplyTwo4x4FMatricesBuffered(m,m,rX.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rY.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rZ.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
     break;
     case ROTATION_ORDER_XZY :
-      multiplyTwo4x4FMatricesBuffered(m,m,rX.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rZ.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rY.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
     break;
     case ROTATION_ORDER_YXZ :
-      multiplyTwo4x4FMatricesBuffered(m,m,rY.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rX.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rZ.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
     break;
     case ROTATION_ORDER_YZX :
-      multiplyTwo4x4FMatricesBuffered(m,m,rY.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rZ.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rX.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
     break;
     case ROTATION_ORDER_ZXY :
-      multiplyTwo4x4FMatricesBuffered(m,m,rZ.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rX.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rY.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
     break;
     case ROTATION_ORDER_ZYX :
-      multiplyTwo4x4FMatricesBuffered(m,m,rZ.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rY.m);
-      multiplyTwo4x4FMatricesBuffered(m,m,rX.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rZ.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rY.m);
+      multiplyTwo4x4FMatricesBuffered(m,m->m,rX.m);
     break;
     case ROTATION_ORDER_RPY:
       fprintf(stderr,"create4x4MatrixFromEulerAnglesWithRotationOrderF can't handle RPY\n");
@@ -516,7 +516,7 @@ void create4x4FTranslationMatrix(struct Matrix4x4OfFloats * m , float x, float y
 
  
 
-void create4x4FScalingMatrix(struct Matrix4x4OfFloats * m , float scaleX, float scaleY, float scaleZ)
+void create4x4FScalingMatrix(struct Matrix4x4OfFloats * m, float scaleX, float scaleY, float scaleZ)
 {
     if (m==0) { return ;} 
     create4x4FIdentityMatrix(m);
@@ -849,13 +849,13 @@ int multiplyTwo4x4FMatricesS(struct Matrix4x4OfFloats * result ,struct Matrix4x4
 
 
 
-int multiplyTwo4x4FMatricesBuffered(float * result , float * matrixA , float * matrixB)
+int multiplyTwo4x4FMatricesBuffered(struct Matrix4x4OfFloats * result , float * matrixA , float * matrixB)
 {
-  float bufA[16];
-   copy4x4FMatrix(bufA,matrixA);
-  float bufB[16];
-   copy4x4FMatrix(bufB,matrixB);
-  return  multiplyTwo4x4FMatricesS(result,bufA,bufB);
+  struct Matrix4x4OfFloats bufA;
+   copy4x4FMatrix(bufA.m,matrixA);
+  struct Matrix4x4OfFloats bufB;
+   copy4x4FMatrix(bufB.m,matrixB);
+  return  multiplyTwo4x4FMatricesS(result,&bufA,&bufB);
 }
 
 
@@ -957,7 +957,7 @@ int transform3DPointFVectorUsing4x4FMatrix(float * resultPoint3D,struct Matrix4x
     {e15 W + e12 X + e13 Y + e14 Z}
   }
 */
-  float * m = transformation4x4;
+  float * m = transformation4x4->m;
   register float X=point3D[0],Y=point3D[1],Z=point3D[2],W=point3D[3];
 
   resultPoint3D[0] =  m[e3] * W + m[e0] * X + m[e1] * Y + m[e2] * Z;
@@ -1031,9 +1031,9 @@ void doRPYTransformationF(
     struct Matrix4x4OfFloats intermediateMatrixPitch;
     struct Matrix4x4OfFloats intermediateMatrixHeading;
     struct Matrix4x4OfFloats intermediateMatrixRoll;
-    create4x4FRotationMatrix(intermediateMatrixRoll.m   , rollInDegrees,      0.0,   0.0,   1.0);
-    create4x4FRotationMatrix(intermediateMatrixHeading.m, yawInDegrees,       0.0,   1.0,   0.0);
-    create4x4FRotationMatrix(intermediateMatrixPitch.m  , pitchInDegrees,     1.0,   0.0,   0.0);
+    create4x4FRotationMatrix(&intermediateMatrixRoll   , rollInDegrees,      0.0,   0.0,   1.0);
+    create4x4FRotationMatrix(&intermediateMatrixHeading, yawInDegrees,       0.0,   1.0,   0.0);
+    create4x4FRotationMatrix(&intermediateMatrixPitch  , pitchInDegrees,     1.0,   0.0,   0.0);
 
     multiplyThree4x4FMatrices(
                               m ,
@@ -1067,7 +1067,7 @@ void create4x4FModelTransformation(
 
     struct Matrix4x4OfFloats intermediateMatrixTranslation={0};
     create4x4FTranslationMatrix(
-                                intermediateMatrixTranslation.m,
+                                &intermediateMatrixTranslation,
                                 x,
                                 y,
                                 z
@@ -1079,7 +1079,7 @@ void create4x4FModelTransformation(
 
     if ( (x==0) && (y==0) && (z==0) )
     {
-      create4x4FIdentityMatrix(intermediateMatrixRotation.m);
+      create4x4FIdentityMatrix(&intermediateMatrixRotation);
     } else
     if (rotationOrder>=ROTATION_ORDER_NUMBER_OF_NAMES)
     {
@@ -1109,8 +1109,8 @@ void create4x4FModelTransformation(
 
   if ( (scaleX!=1.0) || (scaleY!=1.0) || (scaleZ!=1.0) )
       {
-        float intermediateScalingMatrix[16];
-        create4x4FScalingMatrix(intermediateScalingMatrix,scaleX,scaleY,scaleZ);
+        struct Matrix4x4OfFloats intermediateScalingMatrix;
+        create4x4FScalingMatrix(&intermediateScalingMatrix,scaleX,scaleY,scaleZ);
         multiplyThree4x4FMatrices(m,&intermediateMatrixTranslation,&intermediateMatrixRotation,&intermediateScalingMatrix);
       } else
       {

--- a/tools/AmMatrix/matrix4x4Tools.c
+++ b/tools/AmMatrix/matrix4x4Tools.c
@@ -926,8 +926,8 @@ int multiplyThree4x4FMatrices_Naive(float * result , float * matrixA , float * m
 
   int i=0;
   float tmp[16];
-  i+=multiplyTwo4x4FMatrices(tmp,matrixB,matrixC);
-  i+=multiplyTwo4x4FMatrices(result , matrixA , tmp);
+  i+=multiplyTwo4x4FMatrices_Naive(tmp,matrixB,matrixC);
+  i+=multiplyTwo4x4FMatrices_Naive(result , matrixA , tmp);
 
   return (i==2);
 }

--- a/tools/AmMatrix/matrix4x4Tools.h
+++ b/tools/AmMatrix/matrix4x4Tools.h
@@ -91,7 +91,10 @@ void copy4x4DMatrixTo4x4F(float * dest, double * m );
 */  
 void create4x4FIdentityMatrix(struct Matrix4x4OfFloats * m);
 
-int is4x4FIdentityMatrix(struct Matrix4x4OfFloats * m);
+
+int is4x4FIdentityMatrix(float  * m);
+int is4x4FIdentityMatrixS(struct Matrix4x4OfFloats * m);
+
 int is4x4FIdentityMatrixPercisionCompensating(struct Matrix4x4OfFloats * m);
 
 void convert4x4FMatrixToRPY(struct Matrix4x4OfFloats * m ,float *roll,float *pitch,float *yaw);
@@ -269,6 +272,18 @@ int transpose4x4DMatrix(double * mat);
 * @retval 0=failure,1=success
 */
 int multiplyTwo4x4DMatrices(double * result ,double * matrixA ,double * matrixB);
+
+/**
+* @brief Multiply 3x 4x4 Double matrices ( A * B * C )
+* @ingroup AmMatrix
+* @param  Output 4x4 Float Matrix ( should be already allocated )
+* @param  Input 4x4 Float Matrix A
+* @param  Input 4x4 Float Matrix B
+* @param  Input 4x4 Float Matrix C
+* @retval 0=failure,1=success
+*/
+int multiplyThree4x4DMatrices(double * result , double * matrixA , double * matrixB , double * matrixC);
+
 
 /**
 * @brief Multiply 2x 4x4 Float matrices ( A * B )

--- a/tools/AmMatrix/matrix4x4Tools.h
+++ b/tools/AmMatrix/matrix4x4Tools.h
@@ -12,6 +12,38 @@ extern "C"
 {
 #endif
 
+
+//This should be ROTATION_ORDER_NAMESA but it isn't to avoid bugs
+//Since this used to be a variable in some points of the code..
+static const char * ROTATION_ORDER_NAMESA[] =
+{
+  "ROTATION_ORDER_NONE", //0
+  "ROTATION_ORDER_XYZ",//1
+  "ROTATION_ORDER_XZY",//2
+  "ROTATION_ORDER_YXZ",//3
+  "ROTATION_ORDER_YZX",//4
+  "ROTATION_ORDER_ZXY",//5
+  "ROTATION_ORDER_ZYX",//6
+  "ROTATION_ORDER_RPY",//7
+  //--------------------
+  "INVALID_ROTATION_ORDER"
+};
+
+enum ROTATION_ORDER
+{
+  ROTATION_ORDER_NONE=0,
+  ROTATION_ORDER_XYZ,//1
+  ROTATION_ORDER_XZY,//2
+  ROTATION_ORDER_YXZ,//3
+  ROTATION_ORDER_YZX,//4
+  ROTATION_ORDER_ZXY,//5
+  ROTATION_ORDER_ZYX,//6
+  ROTATION_ORDER_RPY,//7
+  //--------------------
+  ROTATION_ORDER_NUMBER_OF_NAMES
+};
+
+
 struct Matrix4x4OfFloats
 {
   /*A Matrix 4x4 aligned to allow for SSE optimized calculations.
@@ -30,6 +62,8 @@ struct Matrix4x4OfFloats
     */
   float __attribute__((aligned(16))) m[16];
 };
+
+
 
 /**
 * @brief Printout an 4x4 Matrix that consists of floats
@@ -93,6 +127,8 @@ void create4x4FIdentityMatrix(struct Matrix4x4OfFloats * m);
 
 
 int is4x4FIdentityMatrix(float * m);
+
+int is4x4FZeroMatrix(float  * m);
 int is4x4FIdentityMatrixS(struct Matrix4x4OfFloats * m);
 
 int is4x4FIdentityMatrixPercisionCompensating(struct Matrix4x4OfFloats * m);
@@ -143,36 +179,6 @@ void create4x4FScalingMatrix(struct Matrix4x4OfFloats * matrix , float scaleX, f
 * @param  Degrees of rotation
 */
 void create4x4FQuaternionMatrix(struct Matrix4x4OfFloats * m ,float qX,float qY,float qZ,float qW);
-
-//This should be ROTATION_ORDER_NAMESA but it isn't to avoid bugs
-//Since this used to be a variable in some points of the code..
-static const char * ROTATION_ORDER_NAMESA[] =
-{
-  "ROTATION_ORDER_NONE", //0
-  "ROTATION_ORDER_XYZ",//1
-  "ROTATION_ORDER_XZY",//2
-  "ROTATION_ORDER_YXZ",//3
-  "ROTATION_ORDER_YZX",//4
-  "ROTATION_ORDER_ZXY",//5
-  "ROTATION_ORDER_ZYX",//6
-  "ROTATION_ORDER_RPY",//7
-  //--------------------
-  "INVALID_ROTATION_ORDER"
-};
-
-enum ROTATION_ORDER
-{
-  ROTATION_ORDER_NONE=0,
-  ROTATION_ORDER_XYZ,//1
-  ROTATION_ORDER_XZY,//2
-  ROTATION_ORDER_YXZ,//3
-  ROTATION_ORDER_YZX,//4
-  ROTATION_ORDER_ZXY,//5
-  ROTATION_ORDER_ZYX,//6
-  ROTATION_ORDER_RPY,//7
-  //--------------------
-  ROTATION_ORDER_NUMBER_OF_NAMES
-};
 
 /**
 * @brief Convert euler angles in degrees to a 4x4 rotation matrix using any rotation order wanted
@@ -313,8 +319,9 @@ int multiplyTwo4x4FMatricesS(struct Matrix4x4OfFloats * result ,struct Matrix4x4
 
 int multiplyTwo4x4FMatricesBuffered(struct Matrix4x4OfFloats * result, float * matrixA, float * matrixB);
 
-int multiplyThree4x4FMatrices(struct Matrix4x4OfFloats * result,struct Matrix4x4OfFloats * matrixA,struct Matrix4x4OfFloats * matrixB ,struct Matrix4x4OfFloats * matrixC);
+int multiplyThree4x4FMatrices(struct Matrix4x4OfFloats * result,struct Matrix4x4OfFloats * matrixA,struct Matrix4x4OfFloats * matrixB,struct Matrix4x4OfFloats * matrixC);
 
+int multiplyThree4x4FMatrices_Naive(float * result , float * matrixA , float * matrixB , float * matrixC);
 
 int multiplyFour4x4FMatrices(struct Matrix4x4OfFloats * result ,struct Matrix4x4OfFloats * matrixA ,struct Matrix4x4OfFloats * matrixB ,struct Matrix4x4OfFloats * matrixC ,struct Matrix4x4OfFloats * matrixD);
  

--- a/tools/AmMatrix/matrix4x4Tools.h
+++ b/tools/AmMatrix/matrix4x4Tools.h
@@ -31,23 +31,6 @@ struct Matrix4x4OfFloats
   float __attribute__((aligned(16))) m[16];
 };
 
-
-/**
-* @brief Allocate a new 4x4 Matrix
-* @ingroup AmMatrix
-* @retval 0=Failure or a pointer to an allocated 3x3 Matrix
-*/
-double * malloc4x4DMatrix();
-
-/**
-* @brief Deallocate an existing 3x3 Matrix
-* @ingroup AmMatrix
-* @param  Pointer to a Pointer of an allocated matrix
-*/
-void free4x4DMatrix(double ** mat);
-
-
-
 /**
 * @brief Printout an 4x4 Matrix that consists of floats
 * @ingroup AmMatrix
@@ -64,8 +47,6 @@ void print4x4FMatrix(const char * str , float * matrix4x4,int forcePrint);
 */
 void print4x4DMatrix(const char * str , double * matrix4x4,int forcePrint);
 
-
-
 /**
 * @brief Copy a 4x4 Matrix of doubles to another
 * @ingroup AmMatrix
@@ -74,8 +55,6 @@ void print4x4DMatrix(const char * str , double * matrix4x4,int forcePrint);
 * @param  Pointer to a Pointer of an allocated doubles matrix
 */
 void copy4x4DMatrix(double * out,double * in);
-
-
 
 
 void copy3x3FMatrixTo4x4F(float * out,float * in);
@@ -97,7 +76,6 @@ void copy4x4FMatrix(float * out,float * in);
 */
 void copy4x4FMatrixTo4x4D(double * out,float * in);
 
-
 /**
 * @brief Convert a 4x4 Matrix from Double To Float
 * @ingroup AmMatrix
@@ -110,24 +88,13 @@ void copy4x4DMatrixTo4x4F(float * dest, double * m );
 * @brief Set an allocated 4x4 matrix to Identity ( diagonal 1 , all else 0 )
 * @ingroup AmMatrix
 * @param  Input/Output Matrix
-*/
-void create4x4DIdentityMatrix(double * m) ;
+*/  
+void create4x4FIdentityMatrix(struct Matrix4x4OfFloats * m);
 
-void create4x4FIdentityMatrix(float * m);
+int is4x4FIdentityMatrix(struct Matrix4x4OfFloats * m);
+int is4x4FIdentityMatrixPercisionCompensating(struct Matrix4x4OfFloats * m);
 
-int is4x4DZeroMatrix(double  * m);
-
-int is4x4DIdentityMatrix(double * m);
-
-
-int is4x4FIdentityMatrix(float  * m);
-int is4x4FIdentityMatrixPercisionCompensating(float  * m);
-
-
-void convert4x4DMatrixToRPY(double *m ,double *roll,double *pitch,double *yaw);
-
-
-
+void convert4x4FMatrixToRPY(struct Matrix4x4OfFloats * m ,float *roll,float *pitch,float *yaw);
 
 /**
 * @brief Convert an allocated 4x4 matrix to a homogeneous Translation rotation
@@ -140,12 +107,9 @@ void convert4x4DMatrixToRPY(double *m ,double *roll,double *pitch,double *yaw);
 */
 void create4x4DRotationMatrix(double * m,double angle, double x, double y, double z) ;
 
+void create4x4FRotationMatrix(struct Matrix4x4OfFloats * m , float angle, float x, float y, float z);
 
-void create4x4FRotationMatrix(float * m , float angle, float x, float y, float z);
-
-
-void create4x4FTranslationMatrix(float * matrix , float x, float y, float z);
-
+void create4x4FTranslationMatrix(struct Matrix4x4OfFloats * m , float x, float y, float z);
 
 /**
 * @brief Convert an allocated 4x4 matrix to a homogeneous 3D Translation
@@ -157,7 +121,6 @@ void create4x4FTranslationMatrix(float * matrix , float x, float y, float z);
 */
 void create4x4DTranslationMatrix(double * matrix,double x, double y, double z);
 
-
 /**
 * @brief Convert an allocated 4x4 matrix to a homogeneous 3D Scaling
 * @ingroup AmMatrix
@@ -166,11 +129,8 @@ void create4x4DTranslationMatrix(double * matrix,double x, double y, double z);
 * @param  Scaling on the Y
 * @param  Scaling on the Z
 * @retval 0=Failure,1=Success
-*/
-void create4x4DScalingMatrix(double * matrix,double scaleX, double scaleY, double scaleZ);
-
-void create4x4FScalingMatrix(float * matrix , float scaleX, float scaleY, float scaleZ);
-
+*/ 
+void create4x4FScalingMatrix(struct Matrix4x4OfFloats * matrix , float scaleX, float scaleY, float scaleZ);
 
 /**
 * @brief Convert a quaternion to 4x4 matrix
@@ -182,10 +142,7 @@ void create4x4FScalingMatrix(float * matrix , float scaleX, float scaleY, float 
 * @param  Quaternion on the W
 * @param  Degrees of rotation
 */
-void create4x4DQuaternionMatrix(double * m , double qX,double qY,double qZ,double qW);
-
-
-
+void create4x4FQuaternionMatrix(struct Matrix4x4OfFloats * m ,float qX,float qY,float qZ,float qW);
 
 //This should be ROTATION_ORDER_NAMESA but it isn't to avoid bugs
 //Since this used to be a variable in some points of the code..
@@ -229,11 +186,11 @@ enum ROTATION_ORDER
 * @param  Rotation Z in euler angles (0-360)
 * @param  Rotation order given by enum ROTATION_ORDER, typically ROTATION_ORDER_ZYX or ROTATION_ORDER_XYZ
 */
-void create4x4DMatrixFromEulerAnglesWithRotationOrder(double * m ,double eulX, double eulY, double eulZ,unsigned int rotationOrder);
-
-
 void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats * m ,float eulX, float eulY, float eulZ,unsigned int rotationOrder);
 
+
+
+void create4x4FMatrixFromEulerAnglesXYZAllInOne(struct Matrix4x4OfFloats * m ,float eulX,float eulY,float eulZ);
 
 /**
 * @brief Convert a quaternion to 4x4 matrix ZYX convention ( standard )
@@ -243,7 +200,7 @@ void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats *
 * @param  Rotation Y in euler angles (0-360)
 * @param  Rotation Z in euler angles (0-360)
 */
-void create4x4DMatrixFromEulerAnglesZYX(double * m ,double eulX, double eulY, double eulZ);
+void create4x4FMatrixFromEulerAnglesZYX(struct Matrix4x4OfFloats * m ,float eulX,float eulY,float eulZ);
 
 
 /**
@@ -252,7 +209,7 @@ void create4x4DMatrixFromEulerAnglesZYX(double * m ,double eulX, double eulY, do
 * @param  Output already allocated 4x4 Matrix
 * @param  Degrees of rotation
 */
-void create4x4DRotationX(double * matrix,double degrees) ;
+void create4x4FRotationX(struct Matrix4x4OfFloats * m,float degrees);
 
 /**
 * @brief Convert an allocated 4x4 matrix to a homogeneous 3D Rotation on the Y axis
@@ -260,7 +217,7 @@ void create4x4DRotationX(double * matrix,double degrees) ;
 * @param  Output already allocated 4x4 Matrix
 * @param  Degrees of rotation
 */
-void create4x4DRotationY(double * matrix,double degrees) ;
+void create4x4FRotationY(struct Matrix4x4OfFloats * m,float degrees);
 
 /**
 * @brief Convert an allocated 4x4 matrix to a homogeneous 3D Rotation on the Z axis
@@ -268,7 +225,7 @@ void create4x4DRotationY(double * matrix,double degrees) ;
 * @param  Output already allocated 4x4 Matrix
 * @param  Degrees of rotation
 */
-void create4x4DRotationZ(double * matrix,double degrees);
+void create4x4FRotationZ(struct Matrix4x4OfFloats * m,float degrees);
 
 
 /**
@@ -277,7 +234,7 @@ void create4x4DRotationZ(double * matrix,double degrees);
 * @param  Input 4x4 Matrix
 * @retval Det(mat)
 */
-double det4x4DMatrix(double * mat) ;
+float det4x4FMatrix(float * mat) ;
 
 /**
 * @brief Invert a 4x4 matrix
@@ -286,10 +243,8 @@ double det4x4DMatrix(double * mat) ;
 * @param  Output ( should be already allocated ) 3x3 Matrix
 * @retval 0=failure,1=success
 */
-int invert4x4DMatrix(double * result,double * mat) ;
+int invert4x4FMatrix(float * result,float * mat) ;
 
-
-int transpose4x4FMatrix(float * mat);
 
 /**
 * @brief Transpose an allocated 4x4 matrix to Identity ( diagonal 1 , all else 0 )
@@ -297,25 +252,8 @@ int transpose4x4FMatrix(float * mat);
 * @param  Input/Output Matrix
 * @retval 0=Failure,1=Success
 */
-int transpose4x4DMatrix(double * mat) ;
-
-
-/**
-* @brief Multiply 2x 4x4 matrices ( A * B )
-* @ingroup AmMatrix
-* @param  Output 4x4 Matrix ( should be already allocated )
-* @param  Input 4x4 Matrix A
-* @param  Input 4x4 Matrix B
-* @retval 0=failure,1=success
-*/
-int multiplyTwo4x4DMatrices(double * result , double * matrixA , double * matrixB);
-
-
-int multiplyTwo4x4DMatricesBuffered(double * result , double * matrixA , double * matrixB);
-
-int multiplyThree4x4DMatrices(double * result , double * matrixA , double * matrixB , double * matrixC);
-
-int multiplyFour4x4DMatrices(double * result , double * matrixA , double * matrixB , double * matrixC , double * matrixD);
+int transpose4x4FMatrix(float * mat);
+  
 
 /**
 * @brief Multiply 2x 4x4 Float matrices ( A * B )
@@ -347,15 +285,9 @@ int multiplyTwo4x4FMatricesBuffered(float * result , float * matrixA , float * m
 
 int multiplyThree4x4FMatrices(struct Matrix4x4OfFloats * result,struct Matrix4x4OfFloats * matrixA,struct Matrix4x4OfFloats * matrixB ,struct Matrix4x4OfFloats * matrixC);
 
-/**
-* @brief Multiply a 4x4 matrix of doubles with a double precision Vector (3D Point)  A*V
-* @ingroup AmMatrix
-* @param  Output Vector ( should be already allocated )
-* @param  Input 4x4 Matrix A
-* @param  Input Vector 4x1 V
-* @retval 0=failure,1=success
-*/
-int transform3DPointDVectorUsing4x4DMatrix(double * resultPoint3D, double * transformation4x4, double * point3D);
+
+int multiplyFour4x4FMatrices(struct Matrix4x4OfFloats * result ,struct Matrix4x4OfFloats * matrixA ,struct Matrix4x4OfFloats * matrixB ,struct Matrix4x4OfFloats * matrixC ,struct Matrix4x4OfFloats * matrixD);
+ 
 
 
 /**

--- a/tools/AmMatrix/matrix4x4Tools.h
+++ b/tools/AmMatrix/matrix4x4Tools.h
@@ -296,7 +296,7 @@ int multiplyTwo4x4FMatrices_SSE(float * result , float * matrixA , float * matri
 
 int multiplyTwo4x4FMatricesS(struct Matrix4x4OfFloats * result ,struct Matrix4x4OfFloats * matrixA ,struct Matrix4x4OfFloats * matrixB);
 
-int multiplyTwo4x4FMatricesBuffered(float * result , float * matrixA , float * matrixB);
+int multiplyTwo4x4FMatricesBuffered(struct Matrix4x4OfFloats * result, float * matrixA, float * matrixB);
 
 int multiplyThree4x4FMatrices(struct Matrix4x4OfFloats * result,struct Matrix4x4OfFloats * matrixA,struct Matrix4x4OfFloats * matrixB ,struct Matrix4x4OfFloats * matrixC);
 

--- a/tools/AmMatrix/matrix4x4Tools.h
+++ b/tools/AmMatrix/matrix4x4Tools.h
@@ -105,11 +105,7 @@ void convert4x4FMatrixToRPY(struct Matrix4x4OfFloats * m ,float *roll,float *pit
 * @param  Y Axis Parameter
 * @param  Z Axis Parameter
 */
-void create4x4DRotationMatrix(double * m,double angle, double x, double y, double z) ;
-
 void create4x4FRotationMatrix(struct Matrix4x4OfFloats * m , float angle, float x, float y, float z);
-
-void create4x4FTranslationMatrix(struct Matrix4x4OfFloats * m , float x, float y, float z);
 
 /**
 * @brief Convert an allocated 4x4 matrix to a homogeneous 3D Translation
@@ -119,7 +115,8 @@ void create4x4FTranslationMatrix(struct Matrix4x4OfFloats * m , float x, float y
 * @param  Y Translation
 * @param  Z Translation
 */
-void create4x4DTranslationMatrix(double * matrix,double x, double y, double z);
+void create4x4FTranslationMatrix(struct Matrix4x4OfFloats * m , float x, float y, float z);
+
 
 /**
 * @brief Convert an allocated 4x4 matrix to a homogeneous 3D Scaling
@@ -240,7 +237,7 @@ float det4x4FMatrix(float * mat) ;
 * @param  Output ( should be already allocated ) 3x3 Matrix
 * @retval 0=failure,1=success
 */
-int invert4x4FMatrix(float * result,float * mat) ;
+int invert4x4FMatrix(struct Matrix4x4OfFloats * result,struct Matrix4x4OfFloats * mat) ;
 
 
 /**
@@ -251,6 +248,27 @@ int invert4x4FMatrix(float * result,float * mat) ;
 */
 int transpose4x4FMatrix(float * mat);
   
+
+
+/**
+* @brief Transpose an allocated 4x4 matrix to Identity using doubles ( diagonal 1 , all else 0 )
+* @ingroup AmMatrix
+* @param  Input/Output Matrix
+* @retval 0=Failure,1=Success
+*/
+int transpose4x4DMatrix(double * mat);
+
+
+
+/**
+* @brief Multiply 2x 4x4 Double matrices ( A * B )
+* @ingroup AmMatrix
+* @param  Output 4x4 Float Matrix ( should be already allocated )
+* @param  Input 4x4 Float Matrix A
+* @param  Input 4x4 Float Matrix B
+* @retval 0=failure,1=success
+*/
+int multiplyTwo4x4DMatrices(double * result ,double * matrixA ,double * matrixB);
 
 /**
 * @brief Multiply 2x 4x4 Float matrices ( A * B )
@@ -295,7 +313,7 @@ int multiplyFour4x4FMatrices(struct Matrix4x4OfFloats * result ,struct Matrix4x4
 * @param  Input Vector 4x1 V
 * @retval 0=failure,1=success
 */
-int transform3DPointFVectorUsing4x4FMatrix(float * resultPoint3D, float * transformation4x4, float * point3D);
+int transform3DPointFVectorUsing4x4FMatrix(float * resultPoint3D,struct Matrix4x4OfFloats * transformation4x4, float * point3D);
 
 /**
 * @brief Multiply a the 3x3 rotational part of a 4x4 matrix with a Normal Vector (3D Point)  A*V
@@ -384,16 +402,16 @@ void create4x4FModelTransformation(
 * @param  Input/Output Vector
 * @retval 0=failure,1=success
 */
-void create4x4DCameraModelViewMatrixForRendering(
-                                                double * m ,
+void create4x4FCameraModelViewMatrixForRendering(
+                                                struct Matrix4x4OfFloats * m ,
                                                 //Rotation Component
-                                                double rotationX_angleDegrees,
-                                                double rotationY_angleDegrees,
-                                                double rotationZ_angleDegrees ,
+                                                float rotationX_angleDegrees,
+                                                float rotationY_angleDegrees,
+                                                float rotationZ_angleDegrees ,
                                                 //Translation Component
-                                                double translationX_angleDegrees,
-                                                double translationY_angleDegrees,
-                                                double translationZ_angleDegrees
+                                                float translationX_angleDegrees,
+                                                float translationY_angleDegrees,
+                                                float translationZ_angleDegrees
                                                );
 
 

--- a/tools/AmMatrix/matrix4x4Tools.h
+++ b/tools/AmMatrix/matrix4x4Tools.h
@@ -12,6 +12,26 @@ extern "C"
 {
 #endif
 
+struct Matrix4x4OfFloats
+{
+  /*A Matrix 4x4 aligned to allow for SSE optimized calculations.
+   * 
+   * Items are stored on the m array using this ordering 
+     0   1   2   3
+     4   5   6   7
+     8   9   10  11
+     12  13  14  15
+     
+     IRC => Item Row/Column => 
+     I11     , I12 , I13 , I14 ,
+     I21     , I22 , I23 , I24 ,
+     I31     , I32 , I33 , I34 ,
+     I41     , I42 , I43 , I44
+    */
+  float __attribute__((aligned(16))) m[16];
+};
+
+
 /**
 * @brief Allocate a new 4x4 Matrix
 * @ingroup AmMatrix
@@ -212,7 +232,7 @@ enum ROTATION_ORDER
 void create4x4DMatrixFromEulerAnglesWithRotationOrder(double * m ,double eulX, double eulY, double eulZ,unsigned int rotationOrder);
 
 
-void create4x4FMatrixFromEulerAnglesWithRotationOrder(float * m ,float eulX, float eulY, float eulZ,unsigned int rotationOrder);
+void create4x4FMatrixFromEulerAnglesWithRotationOrder(struct Matrix4x4OfFloats * m ,float eulX, float eulY, float eulZ,unsigned int rotationOrder);
 
 
 /**
@@ -305,7 +325,7 @@ int multiplyFour4x4DMatrices(double * result , double * matrixA , double * matri
 * @param  Input 4x4 Float Matrix B
 * @retval 0=failure,1=success
 */
-int multiplyTwo4x4FMatrices(float * result , float * matrixA , float * matrixB);
+int multiplyTwo4x4FMatrices_Naive(float * result , float * matrixA , float * matrixB);
 
 
 int codeHasSSE();
@@ -320,9 +340,12 @@ int codeHasSSE();
 */
 int multiplyTwo4x4FMatrices_SSE(float * result , float * matrixA , float * matrixB);
 
+
+int multiplyTwo4x4FMatricesS(struct Matrix4x4OfFloats * result ,struct Matrix4x4OfFloats * matrixA ,struct Matrix4x4OfFloats * matrixB);
+
 int multiplyTwo4x4FMatricesBuffered(float * result , float * matrixA , float * matrixB);
 
-int multiplyThree4x4FMatrices(float * result , float * matrixA , float * matrixB , float * matrixC);
+int multiplyThree4x4FMatrices(struct Matrix4x4OfFloats * result,struct Matrix4x4OfFloats * matrixA,struct Matrix4x4OfFloats * matrixB ,struct Matrix4x4OfFloats * matrixC);
 
 /**
 * @brief Multiply a 4x4 matrix of doubles with a double precision Vector (3D Point)  A*V
@@ -368,23 +391,20 @@ int normalize3DPointFVector(float * vec);
 */
 int normalize3DPointDVector(double * vec);
 
+
 void doRPYTransformationF(
-                         float *m,
+                         struct Matrix4x4OfFloats * m,
                          float  rollInDegrees,
                          float  pitchInDegrees,
                          float  yawInDegrees
                         );
 
-void doRPYTransformationD(
-                         double *m,
-                         double rollInDegrees,
-                         double pitchInDegrees,
-                         double yawInDegrees
-                        );
+
 /*
 */
 
 
+ 
 
 /**
 * @brief Produce a rotation and translation that will bring the scene to the coordinate frame of the camera in order to properly
@@ -405,31 +425,16 @@ void doRPYTransformationD(
 * @param  Input/Output Vector
 * @retval 0=failure,1=success
 */
-void create4x4DModelTransformation(
-                                  double * m ,
-                                  //Rotation Component
-                                  double rotationX,//heading
-                                  double rotationY,//pitch
-                                  double rotationZ,//roll
-                                  unsigned int rotationOrder,
-                                  //Translation Component
-                                  double x, double y, double z ,
-                                  double scaleX, double scaleY, double scaleZ
-                                 );
-
-
-
-
 void create4x4FModelTransformation(
-                                   float * m ,
-                                  //Rotation Component
-                                  float rotationX,//heading
-                                  float rotationY,//pitch
-                                  float rotationZ,//roll
-                                  unsigned int rotationOrder,
-                                  //Translation Component
-                                  float x, float y, float z ,
-                                  float scaleX, float scaleY, float scaleZ
+                                   struct Matrix4x4OfFloats * m ,
+                                   //Rotation Component
+                                   float rotationX,//heading
+                                   float rotationY,//pitch
+                                   float rotationZ,//roll
+                                   unsigned int rotationOrder,
+                                   //Translation Component
+                                   float x, float y, float z ,
+                                   float scaleX, float scaleY, float scaleZ
                                  );
 
 

--- a/tools/AmMatrix/matrix4x4Tools.h
+++ b/tools/AmMatrix/matrix4x4Tools.h
@@ -160,8 +160,6 @@ static const char * ROTATION_ORDER_NAMESA[] =
   "INVALID_ROTATION_ORDER"
 };
 
-
-
 enum ROTATION_ORDER
 {
   ROTATION_ORDER_NONE=0,
@@ -175,7 +173,6 @@ enum ROTATION_ORDER
   //--------------------
   ROTATION_ORDER_NUMBER_OF_NAMES
 };
-
 
 /**
 * @brief Convert euler angles in degrees to a 4x4 rotation matrix using any rotation order wanted
@@ -308,8 +305,8 @@ int transform3DPointFVectorUsing4x4FMatrix(float * resultPoint3D, float * transf
 * @param  Input 4x4 Matrix A
 * @param  Input Vector 4x1 V where W coordinate should be 0
 * @retval 0=failure,1=success
-*/
-int transform3DNormalVectorUsing3x3DPartOf4x4DMatrix(double * resultPoint3D, double * transformation4x4, double * point3D);
+*/ 
+int transform3DNormalVectorUsing3x3FPartOf4x4FMatrix(float * resultPoint3D,struct Matrix4x4OfFloats * transformation4x4,float * point3D);
 
 
 

--- a/tools/AmMatrix/matrix4x4Tools.h
+++ b/tools/AmMatrix/matrix4x4Tools.h
@@ -92,7 +92,7 @@ void copy4x4DMatrixTo4x4F(float * dest, double * m );
 void create4x4FIdentityMatrix(struct Matrix4x4OfFloats * m);
 
 
-int is4x4FIdentityMatrix(float  * m);
+int is4x4FIdentityMatrix(float * m);
 int is4x4FIdentityMatrixS(struct Matrix4x4OfFloats * m);
 
 int is4x4FIdentityMatrixPercisionCompensating(struct Matrix4x4OfFloats * m);

--- a/tools/AmMatrix/matrixCalculations.c
+++ b/tools/AmMatrix/matrixCalculations.c
@@ -515,7 +515,7 @@ void findNormal(float *outX, float *outY, float *outZ,float v1x, float v1y, floa
 
 
 
-int pointFromRelationWithObjectToAbsolute(double * absoluteOutPoint3DRotated, double * objectPosition , double * objectRotation3x3 ,  double * relativeInPoint3DUnrotated)
+int pointFromRelationWithObjectToAbsolute(float * absoluteOutPoint3DRotated,float * objectPosition ,float * objectRotation3x3 ,float * relativeInPoint3DUnrotated)
 {
   //  What we want to do ( in mathematica )
   // (  { {r0,r1,r2,0} , {r3,r4,r5,0} , {r6,r7,r8,0} , {0,0,0,1} } * { { X }  , { Y }  , { Z } , { 1.0 } } ) + { {ObjX} , {ObjY} , {ObjZ} , { 0 }  }
@@ -523,19 +523,19 @@ int pointFromRelationWithObjectToAbsolute(double * absoluteOutPoint3DRotated, do
   //We have a coordinate space in Relation to our object so we want to first rotate our point and then translate it
   //back to absolute coordinate space
 
-  double objectRotation4x4[4*4]={0};
+  struct Matrix4x4OfFloats objectRotation4x4={0};
   //We make the 3x3 matrix onto a 4x4 by adding zeros and 1 as the diagonal element
-  upscale3x3to4x4(objectRotation4x4,objectRotation3x3);
+  upscale3x3Fto4x4F(objectRotation4x4.m,objectRotation3x3);
 
-  objectRotation4x4[e3]=objectPosition[0];
-  objectRotation4x4[e7]=objectPosition[1];
-  objectRotation4x4[e11]=objectPosition[2];
-  objectRotation4x4[e15]=1.0;
+  objectRotation4x4.m[e3]=objectPosition[0];
+  objectRotation4x4.m[e7]=objectPosition[1];
+  objectRotation4x4.m[e11]=objectPosition[2];
+  objectRotation4x4.m[e15]=1.0;
 
-  transform3DPointDVectorUsing4x4DMatrix(absoluteOutPoint3DRotated,objectRotation4x4,relativeInPoint3DUnrotated);
+  transform3DPointFVectorUsing4x4FMatrix(absoluteOutPoint3DRotated,&objectRotation4x4,relativeInPoint3DUnrotated);
 
   //Normalization is done automatically
-  normalize3DPointDVector(absoluteOutPoint3DRotated);
+  normalize3DPointFVector(absoluteOutPoint3DRotated);
 
   return 1;
 }
@@ -546,23 +546,23 @@ int pointFromRelationWithObjectToAbsolute(double * absoluteOutPoint3DRotated, do
     We also have an absolute position of a 3D point , and we want to calculate the relative position
     of the 3D point in relation to the object ( unrotated relative position )
 */
-int pointFromAbsoluteToInRelationWithObject(double * relativeOutPoint3DUnrotated, double * objectPosition , double * objectRotation3x3 , double * absoluteInPoint3DRotated )
+int pointFromAbsoluteToInRelationWithObject(float * relativeOutPoint3DUnrotated,float * objectPosition ,float * objectRotation3x3 ,float * absoluteInPoint3DRotated )
 {
   //printf("pointFromAbsoluteToInRelationWithObject Using Inversion Code\n");
-  double objectRotation4x4[4*4]={0};
+  struct Matrix4x4OfFloats objectRotation4x4={0};
   //We make the 3x3 matrix onto a 4x4 by adding zeros and 1 as the diagonal element
-  upscale3x3to4x4(objectRotation4x4,objectRotation3x3);
+  upscale3x3Fto4x4F(objectRotation4x4.m,objectRotation3x3);
 
-  objectRotation4x4[e3]=objectPosition[0];
-  objectRotation4x4[e7]=objectPosition[1];
-  objectRotation4x4[e11]=objectPosition[2];
-  objectRotation4x4[e15]=1.0;
+  objectRotation4x4.m[e3]=objectPosition[0];
+  objectRotation4x4.m[e7]=objectPosition[1];
+  objectRotation4x4.m[e11]=objectPosition[2];
+  objectRotation4x4.m[e15]=1.0;
 
 
-  double objectInvRotation4x4[4*4]={0};
-  invert4x4DMatrix(objectInvRotation4x4,objectRotation4x4);
+  struct Matrix4x4OfFloats objectInvRotation4x4={0};
+  invert4x4FMatrix(&objectInvRotation4x4,&objectRotation4x4);
 
-  transform3DPointDVectorUsing4x4DMatrix(relativeOutPoint3DUnrotated,objectInvRotation4x4,absoluteInPoint3DRotated);
+  transform3DPointFVectorUsing4x4FMatrix(relativeOutPoint3DUnrotated,&objectInvRotation4x4,absoluteInPoint3DRotated);
   return 1;
 }
 

--- a/tools/AmMatrix/matrixCalculations.c
+++ b/tools/AmMatrix/matrixCalculations.c
@@ -570,19 +570,17 @@ int pointFromAbsoluteToInRelationWithObject(float * relativeOutPoint3DUnrotated,
 
 
 
-
-
 /*
-    We have an object with an absolute Position X,Y,Z (objectPosition[]) and Rotation (objectRotation3x3[])
-    We also have an absolute position of a 3D point , and we want to calculate the relative position
-    of the 3D point in relation to the object ( unrotated relative position )
-*/
-int pointFromAbsoluteToRelationWithObject_PosXYZRotationXYZ(double * relativeOutPoint3DUnrotated, double * objectPosition , double * objectRotation , double * absoluteInPoint3DRotated )
+//BROKEN WHILE TRANSITION FROM DOUBLES TO FLOATS
+// We have an object with an absolute Position X,Y,Z (objectPosition[]) and Rotation (objectRotation3x3[])
+// We also have an absolute position of a 3D point , and we want to calculate the relative position
+// of the 3D point in relation to the object ( unrotated relative position )
+int pointFromAbsoluteToRelationWithObject_PosXYZRotationXYZ(float * relativeOutPoint3DUnrotated,float * objectPosition ,float * objectRotation ,float * absoluteInPoint3DRotated )
 {
-    double objectRotation3x3[9];
+    float objectRotation3x3[9];
     create3x3EulerRotationXYZOrthonormalMatrix(objectRotation3x3,objectRotation);
 
-     pointFromAbsoluteToInRelationWithObject(relativeOutPoint3DUnrotated,objectPosition,objectRotation3x3,absoluteInPoint3DRotated);
+    pointFromAbsoluteToInRelationWithObject(relativeOutPoint3DUnrotated,objectPosition,objectRotation3x3,absoluteInPoint3DRotated);
 
     //We have to try to normalize the output point , although it should already be normalized..
     normalize3DPointDVector(relativeOutPoint3DUnrotated);
@@ -593,14 +591,13 @@ int pointFromAbsoluteToRelationWithObject_PosXYZRotationXYZ(double * relativeOut
 
 
 
-/*
-    We have an object with an absolute Position X,Y,Z (objectPosition[]) and Rotation (objectRotation3x3[])
-    We also have an absolute position of a 3D point , and we want to calculate the relative position
-    of the 3D point in relation to the object ( unrotated relative position )
-*/
-int pointFromAbsoluteToRelationWithObject_PosXYZQuaternionXYZW(double * relativeOutPoint3DUnrotated, double * objectPosition , double * objectQuaternion , double * absoluteInPoint3DRotated )
+//BROKEN WHILE TRANSITION FROM DOUBLES TO FLOATS
+//We have an object with an absolute Position X,Y,Z (objectPosition[]) and Rotation (objectRotation3x3[])
+//We also have an absolute position of a 3D point , and we want to calculate the relative position
+//of the 3D point in relation to the object ( unrotated relative position )
+int pointFromAbsoluteToRelationWithObject_PosXYZQuaternionXYZW(float * relativeOutPoint3DUnrotated,float * objectPosition ,float * objectQuaternion ,float * absoluteInPoint3DRotated )
 {
-    double objectRotation3x3[9];
+    float objectRotation3x3[9];
 
     //printf("Object Position is %f,%f,%f  \n", objectPosition[0], objectPosition[1], objectPosition[2] );
     //printf("Quaternion %f,%f,%f,%f \n",objectQuaternion[0],objectQuaternion[1],objectQuaternion[2],objectQuaternion[3]);
@@ -621,12 +618,11 @@ int pointFromAbsoluteToRelationWithObject_PosXYZQuaternionXYZW(double * relative
 }
 
 
-/*
-    We have an object with a relative Position X,Y,Z to an Object (objectPosition[])
-*/
-int pointFromRelationWithObjectToAbsolute_PosXYZRotationXYZ(double * absoluteOutPoint3DRotated , double * objectPosition , double * objectRotation ,double * relativeInPoint3DUnrotated)
+//BROKEN WHILE TRANSITION FROM DOUBLES TO FLOATS
+//We have an object with a relative Position X,Y,Z to an Object (objectPosition[])
+int pointFromRelationWithObjectToAbsolute_PosXYZRotationXYZ(float * absoluteOutPoint3DRotated ,float * objectPosition ,float * objectRotation ,float * relativeInPoint3DUnrotated)
 {
-    double objectRotation3x3[9]={0};
+    float objectRotation3x3[9]={0};
     create3x3EulerRotationXYZOrthonormalMatrix(objectRotation3x3,objectRotation);
     pointFromRelationWithObjectToAbsolute(absoluteOutPoint3DRotated,objectPosition,objectRotation3x3,relativeInPoint3DUnrotated);
 
@@ -638,12 +634,11 @@ int pointFromRelationWithObjectToAbsolute_PosXYZRotationXYZ(double * absoluteOut
 
 
 
-/*
-    We have an object with a relative Position X,Y,Z to an Object (objectPosition[])
-*/
-int pointFromRelationWithObjectToAbsolute_PosXYZQuaternionXYZW(double * absoluteOutPoint3DRotated , double * objectPosition , double * objectQuaternion ,double * relativeInPoint3DUnrotated)
+//BROKEN WHILE TRANSITION FROM DOUBLES TO FLOATS
+//We have an object with a relative Position X,Y,Z to an Object (objectPosition[])
+int pointFromRelationWithObjectToAbsolute_PosXYZQuaternionXYZW(float * absoluteOutPoint3DRotated , float * objectPosition ,float * objectQuaternion ,float * relativeInPoint3DUnrotated)
 {
-    double objectRotation3x3[9];
+    float objectRotation3x3[9];
 
     //printf("Object Position is %f,%f,%f  \n", objectPosition[0], objectPosition[1], objectPosition[2] );
     //printf("Quaternion %f,%f,%f,%f \n",objectQuaternion[0],objectQuaternion[1],objectQuaternion[2],objectQuaternion[3]);
@@ -662,6 +657,7 @@ int pointFromRelationWithObjectToAbsolute_PosXYZQuaternionXYZW(double * absolute
 
     return 1;
 }
+*/
 
 
 void testMatrices()
@@ -670,3 +666,5 @@ void testMatrices()
    testGJSolver();
   return ; 
 }
+
+

--- a/tools/AmMatrix/matrixCalculations.c
+++ b/tools/AmMatrix/matrixCalculations.c
@@ -360,14 +360,14 @@ static inline float sqrt_fast_approximation(const float x)
 
 
 
-double distanceBetween3DPoints(double * p1, double * p2)
+float distanceBetween3DPoints(float * p1, float * p2)
 {
-  double x1 = p1[0] , y1 = p1[1] , z1 = p1[2];
-  double x2 = p2[0] , y2 = p2[1] , z2 = p2[2];
+  float x1 = p1[0] , y1 = p1[1] , z1 = p1[2];
+  float x2 = p2[0] , y2 = p2[1] , z2 = p2[2];
 
-  double dx=x1-x2;
-  double dy=y1-y2;
-  double dz=z1-z2;
+  float dx=x1-x2;
+  float dy=y1-y2;
+  float dz=z1-z2;
 
   //I Could actually skip this
   //if (x1>=x2) { dx=x1-x2; } else { dx=x2-x1; }
@@ -375,7 +375,7 @@ double distanceBetween3DPoints(double * p1, double * p2)
   //if (z1>=z2) { dz=z1-z2; } else { dz=z2-z1; }
   //==========================
 
-  return (double) sqrt( (dx * dx) + (dy * dy) + (dz * dz) );
+  return (float) sqrt( (dx * dx) + (dy * dy) + (dz * dz) );
 }
 
 
@@ -405,27 +405,24 @@ float squaredDistanceBetween3DPoints(float *x1,float*y1,float *z1,float *x2,floa
 
 
 
-
-
-
-int projectPointsFrom3Dto2D(double * x2D, double * y2D , double * x3D, double *y3D , double * z3D , double * intrinsics , double * rotation3x3 , double * translation)
+int projectPointsFrom3Dto2D(float * x2D,float * y2D ,float * x3D,float *y3D ,float * z3D ,float * intrinsics ,float * rotation3x3 ,float * translation)
 {
-  double fx = intrinsics[0];
-  double fy = intrinsics[4];
-  double cx = intrinsics[2];
-  double cy = intrinsics[5];
+  float fx = intrinsics[0];
+  float fy = intrinsics[4];
+  float cx = intrinsics[2];
+  float cy = intrinsics[5];
 
-  double * t = translation;
-  double * r = rotation3x3;
+  float * t = translation;
+  float * r = rotation3x3;
 
   //Result
   //fx * t0 + cx * t2 + (x3D) * ( fx * r0 + cx * r6 )  + (y3D) * ( fx * r1 + cx * r7 ) + (z3D) * (fx * r2 +cx * r8) / t3 + r7 x3D + r8 * y3D + r9 * z3D
   //fy * t1 + cy * t2 + x3D * ( fy * r3 + cy * r6 )  + y3D * ( fy * r4 + cy * r7 ) + z3D * (fy * r5 +cy * r8) / t3 + r7 x3D + r8 * y3D + r9 * z3D
   //1
 
-  double x2DBuf =  fx * t[0] + cx * t[2] + (*x3D) * ( fx * r[0] + cx * r[6] )  + (*y3D) * ( fx * r[1] + cx * r[7] ) + (*z3D) * (fx * r[2] +cx * r[8]);
-  double y2DBuf =  fy * t[1] + cy * t[2] + (*x3D) * ( fy * r[3] + cy * r[6] )  + (*y3D) * ( fy * r[4] + cy * r[7] ) + (*z3D) * (fy * r[5] +cy * r[8]);
-  double scale =   t[2] + r[6] * (*x3D) + r[7] * (*y3D) + r[8] * (*z3D);
+  float x2DBuf =  fx * t[0] + cx * t[2] + (*x3D) * ( fx * r[0] + cx * r[6] )  + (*y3D) * ( fx * r[1] + cx * r[7] ) + (*z3D) * (fx * r[2] +cx * r[8]);
+  float y2DBuf =  fy * t[1] + cy * t[2] + (*x3D) * ( fy * r[3] + cy * r[6] )  + (*y3D) * ( fy * r[4] + cy * r[7] ) + (*z3D) * (fy * r[5] +cy * r[8]);
+  float scale =   t[2] + r[6] * (*x3D) + r[7] * (*y3D) + r[8] * (*z3D);
 
   if ( scale == 0.0 ) { fprintf(stderr,"could not projectPointsFrom3Dto2D"); return 0; }
   *x2D = x2DBuf / scale;
@@ -436,9 +433,9 @@ int projectPointsFrom3Dto2D(double * x2D, double * y2D , double * x3D, double *y
 
 
 
-int move3DPoint(double * resultPoint3D, double * transformation4x4, double * point3D  )
+int move3DPoint(float * resultPoint3D,struct Matrix4x4OfFloats * transformation4x4,float * point3D)
 {
-  return transform3DPointDVectorUsing4x4DMatrix(resultPoint3D,transformation4x4,point3D);
+  return transform3DPointFVectorUsing4x4FMatrix(resultPoint3D,transformation4x4,point3D);
 }
 
 
@@ -671,27 +668,5 @@ void testMatrices()
 {
    //testHomographySolver();
    testGJSolver();
-  return ;
-
-
-  double A[16]={ 1 ,2 ,3 ,4,
-                 5 ,6 ,7 ,8,
-                 9 ,10,11,12,
-                 13,14,15,16 };
-
-
-  double B[16]={ 1 ,2 ,3 ,4,
-                 4 ,3 ,2 ,1,
-                 1 ,2 ,3 ,4,
-                 4 ,3 ,2 ,1 };
-
-  double Res[16]={0};
-
-  multiplyTwo4x4DMatrices(Res,A,B);
-/*
-  28.000000 26.000000 24.000000 22.000000
-  68.000000 66.000000 64.000000 62.000000
-  108.000000 106.000000 104.000000 102.000000
-  148.000000 146.000000 144.000000 142.000000*/
-
+  return ; 
 }

--- a/tools/AmMatrix/matrixCalculations.c
+++ b/tools/AmMatrix/matrixCalculations.c
@@ -117,7 +117,7 @@ float pointIsInsideCylinder( float * pt1, float * pt2, float lengthsq, float rad
 
 
 
-int slerp2RotTransMatrices4x4(double * result4, double * a4, double * b4 , float step )
+int slerp2RotTransMatrices4x4(float * result4, float * a4, float * b4 , float step )
 {
   if ( (result4==0) || (a4==0) || (b4==0) ) { return 0; }
 
@@ -127,13 +127,13 @@ int slerp2RotTransMatrices4x4(double * result4, double * a4, double * b4 , float
 
   int conventionToUseInternally = 0;
 
-  double qA[4];
+  float qA[4];
   matrix4x42Quaternion(qA, conventionToUseInternally , a4);
 
-  double qB[4];
+  float qB[4];
   matrix4x42Quaternion(qB, conventionToUseInternally , b4);
 
-  double qOut[4];
+  float qOut[4];
   quaternionSlerp( qOut, qA , qB, step);
   quaternion2Matrix4x4(result4 , qOut , conventionToUseInternally );
 
@@ -143,23 +143,7 @@ int slerp2RotTransMatrices4x4(double * result4, double * a4, double * b4 , float
  return 1;
 }
 
-
-
-
-int slerp2RotTransMatrices4x4F(float * result4, float * a4, float * b4 , float step )
-{
- double a4D[16],b4D[16],rD[16];
-
-
- copy4x4FMatrixTo4x4D(a4D,a4);
- copy4x4FMatrixTo4x4D(b4D,b4);
-
-   slerp2RotTransMatrices4x4( rD, a4D, b4D , step );
-
- copy4x4DMatrixTo4x4F(result4, rD);
- return 1;
-}
-
+ 
 
 
 

--- a/tools/AmMatrix/matrixCalculations.h
+++ b/tools/AmMatrix/matrixCalculations.h
@@ -12,7 +12,7 @@ extern "C"
 {
 #endif
 
-
+#include "matrix4x4Tools.h"
 
 /**
 * @author Greg James - gjames@NVIDIA.com , Lisc: Free code - no warranty & no money back.  Use it all you want
@@ -64,7 +64,7 @@ float pointIsInsideCylinder( float * pt1, float * pt2, float lengthsq, float rad
 * @param  Input Translation 3x1
 * @retval 0=Failure,1=Success
 */
-int projectPointsFrom3Dto2D(double * x2D, double * y2D , double * x3D, double *y3D , double * z3D , double * intrinsics , double * rotation3x3 , double * translation);
+int projectPointsFrom3Dto2D(float * x2D,float * y2D ,float * x3D,float *y3D ,float * z3D ,float * intrinsics ,float * rotation3x3 ,float * translation);
 
 
 
@@ -89,7 +89,7 @@ int pointFromRelationToObjectXYZQuaternionXYZWToAbsolute(unsigned int method,  d
 * @param  Input Vector 4x1 V
 * @retval 0=failure,1=success
 */
-int move3DPoint(double * resultPoint3D, double * transformation4x4, double * point3D  );
+int move3DPoint(float * resultPoint3D,struct Matrix4x4OfFloats * transformation4x4,float * point3D);
 
 
 /**
@@ -283,7 +283,7 @@ static inline float sqrt_fast_approximation(const float x)
 * @param  Point B
 * @retval Distance between the two points
 */
-double distanceBetween3DPoints(double * p1, double * p2);
+float distanceBetween3DPoints(float * p1, float * p2);
 
 /**
 * @brief Find an approximation of the distance between 2 points

--- a/tools/AmMatrix/matrixCalculations.h
+++ b/tools/AmMatrix/matrixCalculations.h
@@ -77,7 +77,7 @@ int projectPointsFrom3Dto2D(float * x2D,float * y2D ,float * x3D,float *y3D ,flo
 * @param  Input Array 4x1 of absolute 3D position of the point ( X,Y,Z,W )
 * @retval 0=Failure,1=Success
 */
-int pointFromRelationToObjectXYZQuaternionXYZWToAbsolute(unsigned int method,  double * absoluteInPoint3DRotated , double * objectPosition , double * objectQuaternion ,double * relativeOutPoint3DUnrotated);
+int pointFromRelationToObjectXYZQuaternionXYZWToAbsolute(unsigned int method,float * absoluteInPoint3DRotated ,float * objectPosition,float * objectQuaternion ,float * relativeOutPoint3DUnrotated);
 
 
 
@@ -163,27 +163,17 @@ int pointFromAbsoluteToInRelationWithObject(float * relativeOutPoint3DUnrotated,
 
 
 /**
- * @brief Perform Slerp function between 2 4x4 matrices ( of doubles ) representing rigid transformations
- * @ingroup AmMatrix
- * @param Output Matrix4x4  ( of doubles )
- * @param Input Matrix4x4 A ( of doubles )
- * @param Input Matrix4x4 B ( of doubles )
- * @param Factor , typically should be 0.5 for half and half
- */
-int slerp2RotTransMatrices4x4(double * result4, double * a4, double * b4 , float step );
-
-
-
-
-/**
  * @brief Perform Slerp function between 2 4x4 matrices ( of floats ) representing rigid transformations
  * @ingroup AmMatrix
- * @param Output Matrix4x4   ( of floats )
- * @param Input Matrix4x4 A  ( of floats )
- * @param Input Matrix4x4 B  ( of floats )
+ * @param Output Matrix4x4  ( of floats )
+ * @param Input Matrix4x4 A ( of floats )
+ * @param Input Matrix4x4 B ( of floats )
  * @param Factor , typically should be 0.5 for half and half
  */
-int slerp2RotTransMatrices4x4F(float * result4, float * a4, float * b4 , float step );
+int slerp2RotTransMatrices4x4(float * result4, float * a4, float * b4 , float step );
+
+
+
 
 /**
 * @brief Return the Inner Product of 2 3D points

--- a/tools/AmMatrix/matrixCalculations.h
+++ b/tools/AmMatrix/matrixCalculations.h
@@ -100,7 +100,7 @@ int move3DPoint(float * resultPoint3D,struct Matrix4x4OfFloats * transformation4
 * @param  Input Array 3x3 of a Rotation Matrix
 * @param  Input Array 4x1 of relative 3D position of the point we want to convert ( X,Y,Z,W )
 * @retval 0=Failure,1=Success */
-int pointFromRelationWithObjectToAbsolute(double * absoluteOutPoint3DRotated, double * objectPosition , double * objectRotation3x3 ,  double * relativeInPoint3DUnrotated);
+int pointFromRelationWithObjectToAbsolute(float * absoluteOutPoint3DRotated,float * objectPosition ,float * objectRotation3x3 ,float * relativeInPoint3DUnrotated);
 
 /**
 * @brief Convert 3D Point From an Absolute Coordinate System , to in Relation with a 3D Object using a 3x3 Matrix
@@ -110,7 +110,7 @@ int pointFromRelationWithObjectToAbsolute(double * absoluteOutPoint3DRotated, do
 * @param  Input Array 3x3 of a Rotation Matrix
 * @param  Input Array 4x1 of absolute 3D position of the point we want to convert ( X,Y,Z,W )
 * @retval 0=Failure,1=Success */
-int pointFromAbsoluteToInRelationWithObject(double * relativeOutPoint3DUnrotated, double * objectPosition , double * objectRotation3x3 , double * absoluteInPoint3DRotated );
+int pointFromAbsoluteToInRelationWithObject(float * relativeOutPoint3DUnrotated,float * objectPosition ,float * objectRotation3x3 ,float * absoluteInPoint3DRotated );
 
 
 

--- a/tools/AmMatrix/matrixCalculations.h
+++ b/tools/AmMatrix/matrixCalculations.h
@@ -122,7 +122,7 @@ int pointFromAbsoluteToInRelationWithObject(float * relativeOutPoint3DUnrotated,
 * @param  Input Array of Euler Angles
 * @param  Input Array 4x1 of absolute 3D position of the point we want to convert ( X,Y,Z,W )
 * @retval 0=Failure,1=Success */
-int pointFromAbsoluteToRelationWithObject_PosXYZRotationXYZ(double * relativeOutPoint3DUnrotated, double * objectPosition , double * objectRotation , double * absoluteInPoint3DRotated );
+//int pointFromAbsoluteToRelationWithObject_PosXYZRotationXYZ(float * relativeOutPoint3DUnrotated,float * objectPosition ,float * objectRotation ,float * absoluteInPoint3DRotated );
 
 /**
 * @brief Convert 3D Point From an Absolute Coordinate System , to in Relation with a 3D Object using a Quaternion Rotation
@@ -132,7 +132,7 @@ int pointFromAbsoluteToRelationWithObject_PosXYZRotationXYZ(double * relativeOut
 * @param  Input Array Quaternion qX qY qZ qW order
 * @param  Input Array 4x1 of absolute 3D position of the point we want to convert ( X,Y,Z,W )
 * @retval 0=Failure,1=Success */
-int pointFromAbsoluteToRelationWithObject_PosXYZQuaternionXYZW(double * relativeOutPoint3DUnrotated, double * objectPosition , double * objectQuaternion , double * absoluteInPoint3DRotated );
+//int pointFromAbsoluteToRelationWithObject_PosXYZQuaternionXYZW(float * relativeOutPoint3DUnrotated,float * objectPosition ,float * objectQuaternion ,float * absoluteInPoint3DRotated );
 
 
 /**
@@ -143,7 +143,7 @@ int pointFromAbsoluteToRelationWithObject_PosXYZQuaternionXYZW(double * relative
 * @param  Input Array of Euler Angles
 * @param  Input Array 4x1 of relative 3D position of the point we want to convert ( X,Y,Z,W )
 * @retval 0=Failure,1=Success */
-int pointFromRelationWithObjectToAbsolute_PosXYZRotationXYZ(double * absoluteOutPoint3DRotated , double * objectPosition , double * objectRotation ,double * relativeInPoint3DUnrotated);
+//int pointFromRelationWithObjectToAbsolute_PosXYZRotationXYZ(float * absoluteOutPoint3DRotated ,float * objectPosition ,float * objectRotation ,float * relativeInPoint3DUnrotated);
 
 
 
@@ -155,7 +155,7 @@ int pointFromRelationWithObjectToAbsolute_PosXYZRotationXYZ(double * absoluteOut
 * @param  Input Array Quaternion qX qY qZ qW order
 * @param  Input Array 4x1 of relative 3D position of the point we want to convert ( X,Y,Z,W )
 * @retval 0=Failure,1=Success */
-int pointFromRelationWithObjectToAbsolute_PosXYZQuaternionXYZW(double * absoluteOutPoint3DRotated , double * objectPosition , double * objectQuaternion ,double * relativeInPoint3DUnrotated);
+//int pointFromRelationWithObjectToAbsolute_PosXYZQuaternionXYZW(float * absoluteOutPoint3DRotated ,float * objectPosition ,float * objectQuaternion ,float * relativeInPoint3DUnrotated);
 
 
 

--- a/tools/AmMatrix/matrixOpenGL.c
+++ b/tools/AmMatrix/matrixOpenGL.c
@@ -337,16 +337,16 @@ void glhPerspectivef2(
 
 
 void gldPerspective(
-                     double *matrix,
-                     double fovxInDegrees,
-                     double aspect,
-                     double zNear,
-                     double zFar
+                     float *matrix,
+                     float fovxInDegrees,
+                     float aspect,
+                     float zNear,
+                     float zFar
                    )
 {
    // This code is based off the MESA source for gluPerspective
    // *NOTE* This assumes GL_PROJECTION is the current matrix
-   double xmin, xmax, ymin, ymax;
+   float xmin, xmax, ymin, ymax;
 
    xmax = zNear * tan(fovxInDegrees * M_PI / 360.0);
    xmin = -xmax;
@@ -373,7 +373,7 @@ void gldPerspective(
    matrix[15] = 0.0;
 
    // Add to current matrix
-   //glMultMatrixd(matrix);
+   //glMultMatrixf(matrix);
 }
 
 

--- a/tools/AmMatrix/matrixOpenGL.c
+++ b/tools/AmMatrix/matrixOpenGL.c
@@ -12,14 +12,14 @@
 #define RED     "\033[31m"      /* Red */
 
 
-int convertRodriguezTo3x3(double * result,double * matrix)
+int convertRodriguezTo3x3(float * result,float * matrix)
 {
   if ( (matrix==0) ||  (result==0) ) { return 0; }
 
 
-  double x = matrix[0] , y = matrix[1] , z = matrix[2];
-  double th = sqrt( x*x + y*y + z*z );
-  double cosTh = cos(th);
+  float x = matrix[0] , y = matrix[1] , z = matrix[2];
+  float th = sqrt( x*x + y*y + z*z );
+  float cosTh = cos(th);
   x = x / th; y = y / th; z = z / th;
 
   if ( th < 0.00001 )
@@ -39,7 +39,7 @@ int convertRodriguezTo3x3(double * result,double * matrix)
 
   #if PRINT_MATRIX_DEBUGGING
    fprintf(stderr,"rodriguez %f %f %f\n ",matrix[0],matrix[1],matrix[2]);
-   print3x3DMatrix("Rodriguez Initial", result);
+   print3x3FMatrix("Rodriguez Initial", result);
   #endif // PRINT_MATRIX_DEBUGGING
 
   return 1;
@@ -60,9 +60,9 @@ void changeYandZAxisOpenGL4x4Matrix(float * result,float * matrix)
   multiplyTwo4x4FMatrices_Naive(result,matrix,invertOp.m);  
 }
 
-int convertRodriguezAndTranslationTo4x4DUnprojectionMatrix(double * result4x4, double * rodriguez , double * translation , double scaleToDepthUnit)
+int convertRodriguezAndTranslationTo4x4UnprojectionMatrix(float * result4x4, float * rodriguez , float * translation , float scaleToDepthUnit)
 {
-  double matrix3x3Rotation[16] = {0}; 
+  float matrix3x3Rotation[16] = {0}; 
   
   //Our translation vector is ready to be used!
   #if PRINT_MATRIX_DEBUGGING
@@ -70,18 +70,18 @@ int convertRodriguezAndTranslationTo4x4DUnprojectionMatrix(double * result4x4, d
   #endif // PRINT_MATRIX_DEBUGGING
 
   //Our rodriguez vector should be first converted to a 3x3 Rotation matrix
-  convertRodriguezTo3x3((double*) matrix3x3Rotation , rodriguez);
+  convertRodriguezTo3x3((float*) matrix3x3Rotation , rodriguez);
 
   //Shorthand variables for readable code :P
-  double * m  = result4x4;
-  double * rm = matrix3x3Rotation;
-  double * tm = translation;
+  float * m  = result4x4;
+  float * rm = matrix3x3Rotation;
+  float * tm = translation;
 
 
-  //double scaleToDepthUnit = 1000.0; //Convert Unit to milimeters
-  double Tx = tm[0]*scaleToDepthUnit;
-  double Ty = tm[1]*scaleToDepthUnit;
-  double Tz = tm[2]*scaleToDepthUnit;
+  //float scaleToDepthUnit = 1000.0; //Convert Unit to milimeters
+  float Tx = tm[0]*scaleToDepthUnit;
+  float Ty = tm[1]*scaleToDepthUnit;
+  float Tz = tm[2]*scaleToDepthUnit;
 
 
   /*
@@ -104,14 +104,14 @@ int convertRodriguezAndTranslationTo4x4DUnprojectionMatrix(double * result4x4, d
    m[12]= 0.0;          m[13]= 0.0;         m[14]=0.0;          m[15]=1.0;
 
 
-  print4x4DMatrix("ModelView", result4x4,0); 
+  print4x4FMatrix("ModelView", result4x4,0); 
   return 1;
 }
 
 
-int convertRodriguezAndTranslationToOpenGL4x4DProjectionMatrix(double * result4x4, double * rodriguez , double * translation , double scaleToDepthUnit )
+int convertRodriguezAndTranslationToOpenGL4x4ProjectionMatrix(float * result4x4, float * rodriguez , float * translation , float scaleToDepthUnit )
 {
-  double matrix3x3Rotation[16] = {0};     
+  float matrix3x3Rotation[16] = {0};     
   
   //Our translation vector is ready to be used!
   #if PRINT_MATRIX_DEBUGGING
@@ -120,18 +120,18 @@ int convertRodriguezAndTranslationToOpenGL4x4DProjectionMatrix(double * result4x
 
 
   //Our rodriguez vector should be first converted to a 3x3 Rotation matrix
-  convertRodriguezTo3x3((double*) matrix3x3Rotation , rodriguez);
+  convertRodriguezTo3x3((float*) matrix3x3Rotation , rodriguez);
 
   //Shorthand variables for readable code :P
-  double * m  = result4x4;
-  double * rm = matrix3x3Rotation;
-  double * tm = translation;
+  float * m  = result4x4;
+  float * rm = matrix3x3Rotation;
+  float * tm = translation;
 
 
-  //double scaleToDepthUnit = 1000.0; //Convert Unit to milimeters
-  double Tx = tm[0]*scaleToDepthUnit;
-  double Ty = tm[1]*scaleToDepthUnit;
-  double Tz = tm[2]*scaleToDepthUnit;
+  //float scaleToDepthUnit = 1000.0; //Convert Unit to milimeters
+  float Tx = tm[0]*scaleToDepthUnit;
+  float Ty = tm[1]*scaleToDepthUnit;
+  float Tz = tm[2]*scaleToDepthUnit;
 
   /*
       Here what we want to do is generate a 4x4 matrix that does the normal transformation that our
@@ -146,7 +146,7 @@ int convertRodriguezAndTranslationToOpenGL4x4DProjectionMatrix(double * result4x
 
 
   #if PRINT_MATRIX_DEBUGGING
-   print4x4DMatrix("ModelView", result4x4);
+   print4x4FMatrix("ModelView", result4x4);
    fprintf(stderr,"Matrix will be transposed to become OpenGL format ( i.e. column major )\n");
   #endif // PRINT_MATRIX_DEBUGGING
   

--- a/tools/AmMatrix/matrixOpenGL.c
+++ b/tools/AmMatrix/matrixOpenGL.c
@@ -880,9 +880,9 @@ void prepareRenderingMatrices(
      //glViewport(viewport[0],viewport[1],viewport[2],viewport[3]); //<--Does this do anything?
      
      
-     create4x4FScalingMatrix(&viewMatrix,-1.0,1.0,1.0);
+     create4x4FScalingMatrix(viewMatrix,-1.0,1.0,1.0);
 
-     glGetViewportMatrix(viewportMatrix,viewport[0],viewport[1],viewport[2],viewport[3],near,far);
+     glGetViewportMatrix(viewportMatrix->m,viewport[0],viewport[1],viewport[2],viewport[3],near,far);
 }
 
 

--- a/tools/AmMatrix/matrixOpenGL.c
+++ b/tools/AmMatrix/matrixOpenGL.c
@@ -205,16 +205,17 @@ void buildOpenGLProjectionForIntrinsics   (
 
 
 
-   //TROUBLESHOOTING Left To Right Hand conventions , Thanks Damien 24-06-15
-   float identMat[16];
-   float finalFrustrum[16];
-   create4x4FIdentityMatrix(identMat);
-   identMat[10]=-1;
-   multiplyTwo4x4FMatrices_Naive(finalFrustrum,identMat,frustum);
-   copy4x4FMatrix(frustum,finalFrustrum);
+   //TROUBLESHOOTING Left To Right Hand conventions , Thanks Damien 24-06-15 
+   struct Matrix4x4OfFloats identMat={0};
+   struct Matrix4x4OfFloats finalFrustrum={0};
+   
+   create4x4FIdentityMatrix(&identMat);
+   identMat.m[10]=-1;
+   multiplyTwo4x4FMatrices_Naive(finalFrustrum.m,identMat.m,frustum);
+   copy4x4FMatrix(frustum,finalFrustrum.m);
 
    //This should produce our own Row Major Format
-   transpose4x4FMatrix(finalFrustrum);
+   transpose4x4FMatrix(finalFrustrum.m);
 }
 
 
@@ -437,18 +438,18 @@ void lookAt(
       y[2] /= mag;
     }
 
-   float initial[16];
-   initial[0] = x[0]; initial[1] = x[1]; initial[2] = x[2]; initial[3] = 0.0;
-   initial[4] = y[0]; initial[5] = y[1]; initial[6] = y[2]; initial[7] = 0.0;
-   initial[8] = z[0]; initial[9] = z[1]; initial[10]= z[2]; initial[11]= 0.0;
-   initial[12]= 0.0;  initial[13]= 0.0;  initial[14]= 0.0;  initial[15]= 1.0;
+   struct Matrix4x4OfFloats initial={0};
+   initial.m[0] = x[0]; initial.m[1] = x[1]; initial.m[2] = x[2]; initial.m[3] = 0.0;
+   initial.m[4] = y[0]; initial.m[5] = y[1]; initial.m[6] = y[2]; initial.m[7] = 0.0;
+   initial.m[8] = z[0]; initial.m[9] = z[1]; initial.m[10]= z[2]; initial.m[11]= 0.0;
+   initial.m[12]= 0.0;  initial.m[13]= 0.0;  initial.m[14]= 0.0;  initial.m[15]= 1.0;
 
 
    /* Translate Eye to Origin */
    //glTranslatef(-eyex, -eyey, -eyez);
-   float translation[16];
-   create4x4FTranslationMatrix(translation , -eyex, -eyey, -eyez );
-   multiplyTwo4x4FMatrices_Naive(matrix,initial,translation);
+   struct Matrix4x4OfFloats translation={0};
+   create4x4FTranslationMatrix(&translation , -eyex, -eyey, -eyez );
+   multiplyTwo4x4FMatrices_Naive(matrix,initial.m,translation.m);
 
 }
 
@@ -828,7 +829,7 @@ void glGetViewportMatrix(double * m , double startX,double startY, double width,
 
 
 
-void getModelViewProjectionMatrixFromMatrices(float * output,float * projectionMatrix,float * viewMatrix,float * modelMatrix)
+void getModelViewProjectionMatrixFromMatrices(struct Matrix4x4OfFloats * output,struct Matrix4x4OfFloats * projectionMatrix,struct Matrix4x4OfFloats * viewMatrix,struct Matrix4x4OfFloats * modelMatrix)
 {
     //fprintf(stderr,"Asked To perform multiplication MVP = Projection * View * Model");
 

--- a/tools/AmMatrix/matrixOpenGL.c
+++ b/tools/AmMatrix/matrixOpenGL.c
@@ -159,16 +159,16 @@ int convertRodriguezAndTranslationToOpenGL4x4DProjectionMatrix(double * result4x
 
 
 void buildOpenGLProjectionForIntrinsics   (
-                                                                                              float * frustum,
-                                                                                              int * viewport ,
-                                                                                              float fx,
-                                                                                              float fy,
-                                                                                              float skew,
-                                                                                              float cx, float cy,
-                                                                                              unsigned int imageWidth, unsigned int imageHeight,
-                                                                                              float nearPlane,
-                                                                                              float farPlane
-                                                                                            )
+                                            float * frustum,
+                                            int * viewport ,
+                                            float fx,
+                                            float fy,
+                                            float skew,
+                                            float cx, float cy,
+                                            unsigned int imageWidth, unsigned int imageHeight,
+                                            float nearPlane,
+                                            float farPlane
+                                          )
 {
    fprintf(stderr,"buildOpenGLProjectionForIntrinsics: img(%ux%u) ",imageWidth,imageHeight);
    fprintf(stderr,"fx %0.2f, fy %0.2f, cx %0.2f, cy %0.2f\n",fx,fy,cx,cy);

--- a/tools/AmMatrix/matrixOpenGL.h
+++ b/tools/AmMatrix/matrixOpenGL.h
@@ -20,7 +20,7 @@ extern "C"
 * @param  Input Unit Scale
 * @retval 0=Failure,1=Success
 */
-int convertRodriguezAndTranslationTo4x4DUnprojectionMatrix(double * result4x4, double * rodriguez , double * translation , double scaleToDepthUnit);
+int convertRodriguezAndTranslationTo4x4DUnprojectionMatrix(float * result4x4, float * rodriguez , float * translation , float scaleToDepthUnit);
 
 /**
 * @brief build OpenGL Projection Matrix using Rodriguez Rotation and a translation ( typically coming from OpenCV )
@@ -31,7 +31,7 @@ int convertRodriguezAndTranslationTo4x4DUnprojectionMatrix(double * result4x4, d
 * @param  Input Unit Scale
 * @retval 0=Failure,1=Success
 */
-int convertRodriguezAndTranslationToOpenGL4x4DProjectionMatrix(double * result4x4, double * rodriguez , double * translation , double scaleToDepthUnit);
+int convertRodriguezAndTranslationToOpenGL4x4ProjectionMatrix(float * result4x4, float * rodriguez , float * translation , float scaleToDepthUnit);
 
 
 

--- a/tools/AmMatrix/matrixOpenGL.h
+++ b/tools/AmMatrix/matrixOpenGL.h
@@ -159,7 +159,8 @@ void gldPerspective(
 
   void glGetViewportMatrix(double * m , double startX,double startY, double width,double height , double near , double far);
 
-  void getModelViewProjectionMatrixFromMatrices(double * output, double * projectionMatrix,double * viewMatrix,double * modelMatrix);
+
+  void getModelViewProjectionMatrixFromMatrices(float * output,float * projectionMatrix,float * viewMatrix,float * modelMatrix);
 
 
   void prepareRenderingMatrices(

--- a/tools/AmMatrix/matrixOpenGL.h
+++ b/tools/AmMatrix/matrixOpenGL.h
@@ -137,11 +137,11 @@ void glhPerspectivef2(
 * @param Z Far
 */
 void gldPerspective(
-                     double * matrix,
-                     double fovxInDegrees,
-                     double aspect,
-                     double zNear,
-                     double zFar
+                     float *matrix,
+                     float fovxInDegrees,
+                     float aspect,
+                     float zNear,
+                     float zFar
                    );
 
 

--- a/tools/AmMatrix/matrixOpenGL.h
+++ b/tools/AmMatrix/matrixOpenGL.h
@@ -66,16 +66,16 @@ void buildOpenGLProjectionForIntrinsics   (
 * @param  Input Array 4x1 of absolute 3D position of the point ( X,Y,Z,W )
 * @retval 0=Failure,1=Success
 */
-void buildOpenGLProjectionForIntrinsics_OpenGLColumnMajorD(
-                                             double * frustum,
+void buildOpenGLProjectionForIntrinsics_OpenGLColumnMajor(
+                                             float * frustum,
                                              int * viewport ,
-                                             double fx,
-                                             double fy,
-                                             double skew,
-                                             double cx, double cy,
+                                             float fx,
+                                             float fy,
+                                             float skew,
+                                             float cx,float cy,
                                              unsigned int imageWidth, unsigned int imageHeight,
-                                             double nearPlane,
-                                             double farPlane
+                                             float nearPlane,
+                                             float farPlane
                                            );
 
 
@@ -158,34 +158,34 @@ void gldPerspective(
 
 
 
-  void glGetViewportMatrix(double * m , double startX,double startY, double width,double height , double near , double far);
+  void glGetViewportMatrix(float * m, float startX, float startY, float width, float height, float near, float far);
 
 
 
-void getModelViewProjectionMatrixFromMatrices(struct Matrix4x4OfFloats * output,struct Matrix4x4OfFloats * projectionMatrix,struct Matrix4x4OfFloats * viewMatrix,struct Matrix4x4OfFloats * modelMatrix);
+  void getModelViewProjectionMatrixFromMatrices(struct Matrix4x4OfFloats * output,struct Matrix4x4OfFloats * projectionMatrix,struct Matrix4x4OfFloats * viewMatrix,struct Matrix4x4OfFloats * modelMatrix);
 
 
   void prepareRenderingMatrices(
-                              double fx ,
-                              double fy ,
-                              double skew ,
-                              double cx,
-                              double cy,
-                              double windowWidth,
-                              double windowHeight,
-                              double near,
-                              double far,
-                              double * projectionMatrixD,
-                              double * viewMatrixD,
-                              double * viewportMatrixD
+                              float fx ,
+                              float fy ,
+                              float skew ,
+                              float cx,
+                              float cy,
+                              float windowWidth,
+                              float windowHeight,
+                              float near,
+                              float far,
+                              struct Matrix4x4OfFloats * projectionMatrix,
+                              struct Matrix4x4OfFloats * viewMatrix,
+                              struct Matrix4x4OfFloats * viewportMatrix
                              );
 
 
 void correctProjectionMatrixForDifferentViewport(
-                                                  double * out,
-                                                  double * projectionMatrix,
-                                                  double * originalViewport,
-                                                  double * newViewport
+                                                  float * out,
+                                                  float * projectionMatrix,
+                                                  float * originalViewport,
+                                                  float * newViewport
                                                 );
 
 #ifdef __cplusplus

--- a/tools/AmMatrix/matrixOpenGL.h
+++ b/tools/AmMatrix/matrixOpenGL.h
@@ -8,6 +8,7 @@ extern "C"
 {
 #endif
 
+#include "matrix4x4Tools.h"
 
 
 /**
@@ -160,7 +161,8 @@ void gldPerspective(
   void glGetViewportMatrix(double * m , double startX,double startY, double width,double height , double near , double far);
 
 
-  void getModelViewProjectionMatrixFromMatrices(float * output,float * projectionMatrix,float * viewMatrix,float * modelMatrix);
+
+void getModelViewProjectionMatrixFromMatrices(struct Matrix4x4OfFloats * output,struct Matrix4x4OfFloats * projectionMatrix,struct Matrix4x4OfFloats * viewMatrix,struct Matrix4x4OfFloats * modelMatrix);
 
 
   void prepareRenderingMatrices(

--- a/tools/AmMatrix/quaternions.c
+++ b/tools/AmMatrix/quaternions.c
@@ -43,7 +43,7 @@ enum matrix3x3EnumTranspose
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-void handleQuaternionPackConvention(double qX,double qY,double qZ,double qW , double * packedQuaternionOutput,int quaternionConvention)
+void handleQuaternionPackConvention(float qX,float qY,float qZ,float qW , float * packedQuaternionOutput,int quaternionConvention)
 {
     switch (quaternionConvention)
     {
@@ -66,7 +66,7 @@ void handleQuaternionPackConvention(double qX,double qY,double qZ,double qW , do
     }
 }
 
-void handleQuaternionUnpackConvention(double * packedQuaternionInput,double *qXOut,double *qYOut,double *qZOut,double *qWOut ,int quaternionConvention)
+void handleQuaternionUnpackConvention(float * packedQuaternionInput,float *qXOut,float *qYOut,float *qZOut,float *qWOut ,int quaternionConvention)
 {
     switch (quaternionConvention)
     {
@@ -93,18 +93,18 @@ void handleQuaternionUnpackConvention(double * packedQuaternionInput,double *qXO
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
-int normalizeQuaternions(double *qX,double *qY,double *qZ,double *qW)
+int normalizeQuaternions(float *qX,float *qY,float *qZ,float *qW)
 {
 #if USE_FAST_NORMALIZATION
     // Works best when quat is already almost-normalized
-    double f = (double) (3.0 - (((*qX) * (*qX)) + ( (*qY) * (*qY) ) + ( (*qZ) * (*qZ)) + ((*qW) * (*qW)))) / 2.0;
+    float f = (float) (3.0 - (((*qX) * (*qX)) + ( (*qY) * (*qY) ) + ( (*qZ) * (*qZ)) + ((*qW) * (*qW)))) / 2.0;
     *qX *= f;
     *qY *= f;
     *qZ *= f;
     *qW *= f;
 #else
-    double sqrtDown = (double) sqrt(((*qX) * (*qX)) + ( (*qY) * (*qY) ) + ( (*qZ) * (*qZ)) + ((*qW) * (*qW)));
-    double f = (double) 1 / sqrtDown;
+    float sqrtDown = (float) sqrt(((*qX) * (*qX)) + ( (*qY) * (*qY) ) + ( (*qZ) * (*qZ)) + ((*qW) * (*qW)));
+    float f = (float) 1 / sqrtDown;
     *qX *= f;
     *qY *= f;
     *qZ *= f;
@@ -114,25 +114,25 @@ int normalizeQuaternions(double *qX,double *qY,double *qZ,double *qW)
 }
 
 
-double innerProductQuaternions(double qAX,double qAY,double qAZ,double qAW ,
-                               double qBX,double qBY,double qBZ,double qBW)
+float innerProductQuaternions(float qAX,float qAY,float qAZ,float qAW ,
+                               float qBX,float qBY,float qBZ,float qBW)
 {
-    return (double) ((qAX * qBX) + (qAY * qBY)+ (qAZ * qBZ) + (qAW * qBW));
+    return (float) ((qAX * qBX) + (qAY * qBY)+ (qAZ * qBZ) + (qAW * qBW));
 }
 
 
-double anglesBetweenQuaternions(double qAX,double qAY,double qAZ,double qAW ,
-                                double qBX,double qBY,double qBZ,double qBW)
+float anglesBetweenQuaternions(float qAX,float qAY,float qAZ,float qAW ,
+                                float qBX,float qBY,float qBZ,float qBW)
 {
-    double rads= acos(innerProductQuaternions(qAX,qAY,qAZ,qAW,qBX,qBY,qBZ,qBW));
+    float rads= acos(innerProductQuaternions(qAX,qAY,qAZ,qAW,qBX,qBY,qBZ,qBW));
 
-    return (double)  /*Why is the *2 needed ? */ 2* /*Why?*/ (rads * 180) / PI;
+    return (float)  /*Why is the *2 needed ? */ 2* /*Why?*/ (rads * 180) / PI;
 }
 
 
-void multiplyQuaternions(double * qXOut,double * qYOut,double * qZOut,double * qWOut,
-                         double qAX,double qAY,double qAZ,double qAW ,
-                         double qBX,double qBY,double qBZ,double qBW)
+void multiplyQuaternions(float * qXOut,float * qYOut,float * qZOut,float * qWOut,
+                         float qAX,float qAY,float qAZ,float qAW ,
+                         float qBX,float qBY,float qBZ,float qBW)
 {
     *qXOut = (qBX*qAW)+(qBW*qAX)+(qBZ*qAY)-(qBY*qAZ);
     *qYOut = (qBY*qAW)-(qBZ*qAX)+(qBW*qAY)+(qBX*qAZ);
@@ -143,13 +143,13 @@ void multiplyQuaternions(double * qXOut,double * qYOut,double * qZOut,double * q
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-void euler2Quaternions(double * quaternions,double * euler,int quaternionConvention)
+void euler2Quaternions(float * quaternions,float * euler,int quaternionConvention)
 {
     //This conversion follows the rule euler X Y Z  to quaternions W X Y Z
     //Our input is degrees so we convert it to radians for the sin/cos functions
-    double eX = (double) (euler[0] * PI) / 180;
-    double eY = (double) (euler[1] * PI) / 180;
-    double eZ = (double) (euler[2] * PI) / 180;
+    float eX = (float) (euler[0] * PI) / 180;
+    float eY = (float) (euler[1] * PI) / 180;
+    float eZ = (float) (euler[2] * PI) / 180;
 
     //fprintf(stderr,"eX %f eY %f eZ %f\n",eX,eY,eZ);
 
@@ -158,29 +158,29 @@ void euler2Quaternions(double * quaternions,double * euler,int quaternionConvent
     //eY Pitch θ - rotation about the Y-axis
     //eZ Yaw   ψ - rotation about the Z-axis
 
-    double cosX2 = cos((double) eX/2); //cos(φ/2);
-    double sinX2 = sin((double) eX/2); //sin(φ/2);
-    double cosY2 = cos((double) eY/2); //cos(θ/2);
-    double sinY2 = sin((double) eY/2); //sin(θ/2);
-    double cosZ2 = cos((double) eZ/2); //cos(ψ/2);
-    double sinZ2 = sin((double) eZ/2); //sin(ψ/2);
+    float cosX2 = cos((float) eX/2); //cos(φ/2);
+    float sinX2 = sin((float) eX/2); //sin(φ/2);
+    float cosY2 = cos((float) eY/2); //cos(θ/2);
+    float sinY2 = sin((float) eY/2); //sin(θ/2);
+    float cosZ2 = cos((float) eZ/2); //cos(ψ/2);
+    float sinZ2 = sin((float) eZ/2); //sin(ψ/2);
 
 
 
 
-    double qX = (sinX2 * cosY2 * cosZ2) - (cosX2 * sinY2 * sinZ2);
-    double qY = (cosX2 * sinY2 * cosZ2) + (sinX2 * cosY2 * sinZ2);
-    double qZ = (cosX2 * cosY2 * sinZ2) - (sinX2 * sinY2 * cosZ2);
-    double qW = (cosX2 * cosY2 * cosZ2) + (sinX2 * sinY2 * sinZ2);
+    float qX = (sinX2 * cosY2 * cosZ2) - (cosX2 * sinY2 * sinZ2);
+    float qY = (cosX2 * sinY2 * cosZ2) + (sinX2 * cosY2 * sinZ2);
+    float qZ = (cosX2 * cosY2 * sinZ2) - (sinX2 * sinY2 * cosZ2);
+    float qW = (cosX2 * cosY2 * cosZ2) + (sinX2 * sinY2 * sinZ2);
 
     handleQuaternionPackConvention(qX,qY,qZ,qW,quaternions,quaternionConvention);
 }
 
 
 
-void quaternions2Euler(double * euler,double * quaternions,int quaternionConvention)
+void quaternions2Euler(float * euler,float * quaternions,int quaternionConvention)
 {
-    double qX,qY,qZ,qW;
+    float qX,qY,qZ,qW;
 
     handleQuaternionUnpackConvention(quaternions,&qX,&qY,&qZ,&qW,quaternionConvention);
 
@@ -190,19 +190,19 @@ void quaternions2Euler(double * euler,double * quaternions,int quaternionConvent
     //e3 Yaw   - rZ: rotation about the Z-axis
 
     //Shorthand to go according to http://graphics.wikia.com/wiki/Conversion_between_quaternions_and_Euler_angles
-    double q0=qW , q1 = qX , q2 = qY , q3 = qZ;
-    double q0q1 = (double) q0*q1 , q2q3 = (double) q2*q3;
-    double q0q2 = (double) q0*q2 , q3q1 = (double) q3*q1;
-    double q0q3 = (double) q0*q3 , q1q2 = (double) q1*q2;
+    float q0=qW , q1 = qX , q2 = qY , q3 = qZ;
+    float q0q1 = (float) q0*q1 , q2q3 = (float) q2*q3;
+    float q0q2 = (float) q0*q2 , q3q1 = (float) q3*q1;
+    float q0q3 = (float) q0*q3 , q1q2 = (float) q1*q2;
 
 
-    double eXDenominator = ( 1.0 - 2.0 * (q1*q1 + q2*q2) );
+    float eXDenominator = ( 1.0 - 2.0 * (q1*q1 + q2*q2) );
     if (eXDenominator == 0.0 )
     {
         fprintf(stderr,"Gimbal lock detected , cannot convert to euler coordinates\n");
         return;
     }
-    double eYDenominator = ( 1.0 - 2.0 * ( q2*q2 + q3*q3) );
+    float eYDenominator = ( 1.0 - 2.0 * ( q2*q2 + q3*q3) );
     if (eYDenominator == 0.0 )
     {
         fprintf(stderr,"Gimbal lock detected , cannot convert to euler coordinates\n");
@@ -238,9 +238,9 @@ void quaternions2Euler(double * euler,double * quaternions,int quaternionConvent
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-void quaternionSlerp(double * qOut, double * q0,double * q1,double t)
+void quaternionSlerp(float * qOut, float * q0,float * q1,float t)
 {
-    double product = (q0[0]*q1[0]) + (q0[1]*q1[1]) + (q0[2]*q1[2]) + (q0[3]*q1[3]); // -1,1)
+    float product = (q0[0]*q1[0]) + (q0[1]*q1[1]) + (q0[2]*q1[2]) + (q0[3]*q1[3]); // -1,1)
     if (product<-1.0)
     {
         product=-1.0;
@@ -250,8 +250,8 @@ void quaternionSlerp(double * qOut, double * q0,double * q1,double t)
         product= 1.0;
     }
 
-    double omega = acos(product);
-    double absOmega = omega;
+    float omega = acos(product);
+    float absOmega = omega;
     if (absOmega<0.0)
     {
         absOmega=-1*absOmega;
@@ -269,9 +269,9 @@ void quaternionSlerp(double * qOut, double * q0,double * q1,double t)
     }
 
 
-    double som = sin(omega);
-    double st0 = sin((1-t) * omega) / som;
-    double st1 = sin(t * omega) / som;
+    float som = sin(omega);
+    float st0 = sin((1-t) * omega) / som;
+    float st1 = sin(t * omega) / som;
 
     qOut[0] = q0[0]*st0 + q1[0]*st1;
     qOut[1] = q0[1]*st0 + q1[1]*st1;
@@ -281,13 +281,13 @@ void quaternionSlerp(double * qOut, double * q0,double * q1,double t)
     return;
 }
 
-void quaternion2Matrix3x3(double * matrix3x3,double * quaternions,int quaternionConvention)
+void quaternion2Matrix3x3(float * matrix3x3,float * quaternions,int quaternionConvention)
 {
     //http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToMatrix/index.htm
-    double qX,qY,qZ,qW;
+    float qX,qY,qZ,qW;
     handleQuaternionUnpackConvention(quaternions,&qX,&qY,&qZ,&qW,quaternionConvention);
 
-    double * m = matrix3x3;
+    float * m = matrix3x3;
 
     m[m0]=1 -(2*qY*qY) - (2*qZ*qZ); /*|*/  m[m1]=(2*qX*qY) - (2*qZ*qW);     /*|*/ m[m2]=(2*qX*qZ) + (2*qY*qW);
     m[m3]=(2*qX*qY) + (2*qZ*qW);    /*|*/  m[m4]=1 - (2*qX*qX) - (2*qZ*qZ); /*|*/ m[m5]=(2*qY*qZ) - (2*qX*qW);
@@ -298,13 +298,13 @@ void quaternion2Matrix3x3(double * matrix3x3,double * quaternions,int quaternion
 
 
 
-void quaternion2Matrix4x4(double * matrix4x4,double * quaternions,int quaternionConvention)
+void quaternion2Matrix4x4(float * matrix4x4,float * quaternions,int quaternionConvention)
 {
     //http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToMatrix/index.htm
-    double qX,qY,qZ,qW;
+    float qX,qY,qZ,qW;
     handleQuaternionUnpackConvention(quaternions,&qX,&qY,&qZ,&qW,quaternionConvention);
 
-    double * m = matrix4x4;
+    float * m = matrix4x4;
 
     m[0]=1 -(2*qY*qY) - (2*qZ*qZ); /*|*/  m[1]=(2*qX*qY) - (2*qZ*qW);     /*|*/ m[2]=(2*qX*qZ) + (2*qY*qW);          m[3]=0.0;
     m[4]=(2*qX*qY) + (2*qZ*qW);    /*|*/  m[5]=1 - (2*qX*qX) - (2*qZ*qZ); /*|*/ m[6]=(2*qY*qZ) - (2*qX*qW);          m[7]=0.0;
@@ -315,11 +315,11 @@ void quaternion2Matrix4x4(double * matrix4x4,double * quaternions,int quaternion
 }
 
 
-void matrix4x42Quaternion(double * quaternions,int quaternionConvention,double * matrix4x4)
+void matrix4x42Quaternion(float * quaternions,int quaternionConvention,float * matrix4x4)
 {
 //http://www.gamasutra.com/view/feature/131686/rotating_objects_using_quaternions.php
-    double qX,qY,qZ,qW;
-    double m[4][4];
+    float qX,qY,qZ,qW;
+    float m[4][4];
     m[0][0] = matrix4x4[m0_0];    m[0][1] = matrix4x4[m0_1];    m[0][2] = matrix4x4[m0_2];    m[0][3] = matrix4x4[m0_3];
     m[1][0] = matrix4x4[m1_0];    m[1][1] = matrix4x4[m1_1];    m[1][2] = matrix4x4[m1_2];    m[1][3] = matrix4x4[m1_3];
     m[2][0] = matrix4x4[m2_0];    m[0][1] = matrix4x4[m2_1];    m[0][2] = matrix4x4[m2_2];    m[0][3] = matrix4x4[m2_3];
@@ -365,9 +365,9 @@ void matrix4x42Quaternion(double * quaternions,int quaternionConvention,double *
 
 
 
-void matrix3x32Quaternion(double * quaternions,int quaternionConvention,double * m3)
+void matrix3x32Quaternion(float * quaternions,int quaternionConvention,float * m3)
 {
-  double m4[16];
+  float m4[16];
 
   m4[0]=m3[0];  m4[1]=m3[1];  m4[2]=m3[2];  m4[3]=0.0;
   m4[4]=m3[3];  m4[5]=m3[4];  m4[6]=m3[5];  m4[7]=0.0;
@@ -378,17 +378,17 @@ void matrix3x32Quaternion(double * quaternions,int quaternionConvention,double *
 }
 
 
-void axisAngle2Quaternion(double * quaternionOutput,double xx,double yy,double zz,double a, int quaternionConvention)
+void axisAngle2Quaternion(float * quaternionOutput,float xx,float yy,float zz,float a, int quaternionConvention)
 {
     // Here we calculate the sin( theta / 2) once for optimization
-    double aDeg= a*PI_DIV_180;
-    double sin_aDegDiv2 = sin( aDeg / 2.0 );
+    float aDeg= a*PI_DIV_180;
+    float sin_aDegDiv2 = sin( aDeg / 2.0 );
 
     // Calculate the x, y and z of the quaternion
-    double x = xx * sin_aDegDiv2;
-    double y = yy * sin_aDegDiv2;
-    double z = zz * sin_aDegDiv2;
-    double w = cos( aDeg / 2.0 );
+    float x = xx * sin_aDegDiv2;
+    float y = yy * sin_aDegDiv2;
+    float z = zz * sin_aDegDiv2;
+    float w = cos( aDeg / 2.0 );
 
     // Calcualte the w value by cos( theta / 2 )
     normalizeQuaternions(&x,&y,&z,&w);
@@ -397,14 +397,14 @@ void axisAngle2Quaternion(double * quaternionOutput,double xx,double yy,double z
 }
 
 
-void quaternionRotate(double * quaternion , double rotX , double rotY, double rotZ , double angleDegrees , int quaternionConvention)
+void quaternionRotate(float * quaternion , float rotX , float rotY, float rotZ , float angleDegrees , int quaternionConvention)
 {
-    double rotationQuaternion[4]={0};
+    float rotationQuaternion[4]={0};
     axisAngle2Quaternion(rotationQuaternion,rotX,rotY,rotZ,angleDegrees,quaternionConvention);
 
 
     normalizeQuaternions(&quaternion[pQX],&quaternion[pQY],&quaternion[pQZ],&quaternion[pQW]);
-    double result[4]={0};
+    float result[4]={0};
     multiplyQuaternions(&result[pQX],&result[pQY],&result[pQZ],&result[pQW],
                         rotationQuaternion[pQX],rotationQuaternion[pQY],rotationQuaternion[pQZ],rotationQuaternion[pQW],
                         quaternion[pQX],quaternion[pQY],quaternion[pQZ],quaternion[pQW] );
@@ -415,9 +415,9 @@ void quaternionRotate(double * quaternion , double rotX , double rotY, double ro
 
 
 //http://lolengine.net/blog/2013/09/18/beautiful-maths-quaternion-from-vectors
-void quaternionFromTwoVectors(double * quaternionOutput , double * vA , double * vB)
+void quaternionFromTwoVectors(float * quaternionOutput , float * vA , float * vB)
 {
-    double dotProductOfVectors = vA[0]*vB[0] + vA[1]*vB[1] + vA[2]*vB[2];
+    float dotProductOfVectors = vA[0]*vB[0] + vA[1]*vB[1] + vA[2]*vB[2];
     float m = sqrt(2.f + 2.f * dotProductOfVectors);
     float wD = (1.f / m);
 

--- a/tools/AmMatrix/quaternions.h
+++ b/tools/AmMatrix/quaternions.h
@@ -1,5 +1,5 @@
 /** @file quaternions.h
- *  @brief This is a small math library that deals with quaternions , doubles are used for maximum precision
+ *  @brief This is a small math library that deals with quaternions , floats are used 
  *
  *  @author Ammar Qammaz (AmmarkoV)
  */
@@ -42,7 +42,7 @@ enum quatOrderXYZW
  * @param The convention used for quaternions ( see enum quatOrder )
  * @retval Nothing , no return value
  */
-void euler2Quaternions(double * quaternions,double * euler,int quaternionConvention);
+void euler2Quaternions(float * quaternions,float * euler,int quaternionConvention);
 
 
 /**
@@ -52,7 +52,7 @@ void euler2Quaternions(double * quaternions,double * euler,int quaternionConvent
  * @param Quaternions , The input quaternions in the order declared by enum quatOrder
  * @param The convention used for quaternions ( see enum quatOrder )
  */
-void quaternions2Euler(double * euler,double * quaternions,int quaternionConvention);
+void quaternions2Euler(float * euler,float * quaternions,int quaternionConvention);
 
 
 /**
@@ -63,7 +63,7 @@ void quaternions2Euler(double * euler,double * quaternions,int quaternionConvent
  * @param Input Quaternion B
  * @param Factor , typically should be 0.5 for half and half
  */
-void quaternionSlerp(double * qOut, double * q0,double * q1,double t);
+void quaternionSlerp(float * qOut, float * q0,float * q1,float t);
 
 /**
  * @brief Normalize Quaternion
@@ -75,32 +75,32 @@ void quaternionSlerp(double * qOut, double * q0,double * q1,double t);
  * @param Input/Output , qW
  * @retval 1=Success/0=Failure
  */
-int normalizeQuaternions(double *qX,double *qY,double *qZ,double *qW);
+int normalizeQuaternions(float *qX,float *qY,float *qZ,float *qW);
 
 /**
  * @brief Convert Quaternion to a 3x3 Matrix
  * @ingroup quaternions
  * @param
- * @param Output 3x3 double matrix
+ * @param Output 3x3 float matrix
  * @param Input quaternion
  * @param Input quaternion convention used
  */
-void quaternion2Matrix3x3(double * matrix3x3,double * quaternions,int quaternionConvention);
+void quaternion2Matrix3x3(float * matrix3x3,float * quaternions,int quaternionConvention);
 
 /**
  * @brief Convert Quaternion to a 4x4 Matrix
  * @ingroup quaternions
  * @param
- * @param Output 4x4 double matrix
+ * @param Output 4x4 float matrix
  * @param Input quaternion
  * @param Input quaternion convention used
  */
-void quaternion2Matrix4x4(double * matrix4x4,double * quaternions,int quaternionConvention);
+void quaternion2Matrix4x4(float * matrix4x4,float * quaternions,int quaternionConvention);
 
 
 
-void matrix4x42Quaternion(double * quaternions,int quaternionConvention,double * matrix4x4);
-void matrix3x32Quaternion(double * quaternions,int quaternionConvention,double * m3);
+void matrix4x42Quaternion(float * quaternions,int quaternionConvention,float * matrix4x4);
+void matrix3x32Quaternion(float * quaternions,int quaternionConvention,float * m3);
 
 /**
  * @brief Calculate the Inner Product of Two Quaternions
@@ -117,8 +117,8 @@ void matrix3x32Quaternion(double * quaternions,int quaternionConvention,double *
  * @param Quaternion B qW
  * @retval Inner Product
  */
-double innerProductQuaternions(double qAX,double qAY,double qAZ,double qAW ,
-                               double qBX,double qBY,double qBZ,double qBW);
+float innerProductQuaternions(float qAX,float qAY,float qAZ,float qAW ,
+                               float qBX,float qBY,float qBZ,float qBW);
 
 
 
@@ -137,15 +137,15 @@ double innerProductQuaternions(double qAX,double qAY,double qAZ,double qAW ,
  * @param Quaternion B qW
  * @retval Angle Between the Two
  */
-double anglesBetweenQuaternions(double qAX,double qAY,double qAZ,double qAW ,
-                                double qBX,double qBY,double qBZ,double qBW);
+float anglesBetweenQuaternions(float qAX,float qAY,float qAZ,float qAW ,
+                                float qBX,float qBY,float qBZ,float qBW);
 
 
 
-void quaternionRotate(double * quaternion , double rotX , double rotY, double rotZ , double angleDegrees , int quaternionConvention);
+void quaternionRotate(float * quaternion , float rotX , float rotY, float rotZ , float angleDegrees , int quaternionConvention);
 
 
-void quaternionFromTwoVectors(double * quaternionOutput , double * vA , double * vB);
+void quaternionFromTwoVectors(float * quaternionOutput , float * vA , float * vB);
 
 #ifdef __cplusplus
 }

--- a/tools/AmMatrix/simpleRenderer.h
+++ b/tools/AmMatrix/simpleRenderer.h
@@ -15,6 +15,9 @@ extern "C"
 {
 #endif
 
+#include "matrix4x4Tools.h"
+
+
 /**
  * @brief This structure holds the 3D renderer configuration, if you want to initialize this structure please use simpleRendererDefaults
  * @ingroup simpleRenderer
@@ -36,10 +39,10 @@ struct simpleRenderer
   int removeObjectPosition;
 
 
-  float projectionMatrix[16];
-  float viewMatrix[16];
-  float modelMatrix[16];
-  float modelViewMatrix[16];
+  struct Matrix4x4OfFloats projectionMatrix;
+  struct Matrix4x4OfFloats viewMatrix;
+  struct Matrix4x4OfFloats modelMatrix;
+  struct Matrix4x4OfFloats modelViewMatrix;
   int   viewport[4];
 };
 

--- a/tools/Codecs/bmpInput.c
+++ b/tools/Codecs/bmpInput.c
@@ -130,7 +130,7 @@ SaveDIBitmap(const char *filename, /* I - File to load */
     switch (info->bmiHeader.biCompression)
 	{
 	case BI_BITFIELDS :
-            infosize += 12; /* Add 3 RGB doubleword masks */
+            infosize += 12; /* Add 3 RGB dou ble word masks */
             if (info->bmiHeader.biClrUsed == 0)
 	      break;
 	case BI_RGB :
@@ -341,7 +341,7 @@ SaveDIBitmap(const char *filename, /* I - File to load */
     switch (info->bmiHeader.biCompression)
 	{
 	case BI_BITFIELDS :
-            infosize += 12; /* Add 3 RGB doubleword masks */
+            infosize += 12; /* Add 3 RGB dou ble word masks */
             if (info->bmiHeader.biClrUsed == 0)
 	      break;
 	case BI_RGB :


### PR DESCRIPTION
Pretty huge batch of changes, math code uses floats instead of doubles for better performance, 4x4 matrix code now has SSE assembly that can be switched on given the correct CMake flags..
the TRI models are also float only now..

